### PR TITLE
Add schema generator and Swift type skeletons

### DIFF
--- a/Scripts/SchemaGen.swift
+++ b/Scripts/SchemaGen.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct Schema: Decodable {
+    struct Definition: Decodable {
+        let description: String?
+    }
+
+    let defs: [String: Definition]
+
+    enum CodingKeys: String, CodingKey {
+        case defs = "$defs"
+    }
+}
+
+func typeName(from rawName: String) -> String {
+    let parts = rawName.split { !$0.isLetter && !$0.isNumber }
+    return parts.map { part in
+        part.prefix(1).uppercased() + part.dropFirst()
+    }.joined()
+}
+
+let fm = FileManager.default
+let baseURL = URL(fileURLWithPath: fm.currentDirectoryPath)
+let schemaURL = baseURL.appendingPathComponent("midi2.full.closed.schema.json")
+let sourcesURL = baseURL.appendingPathComponent("Sources/MIDI2", isDirectory: true)
+let testsURL = baseURL.appendingPathComponent("Tests/MIDI2Tests", isDirectory: true)
+
+try fm.createDirectory(at: sourcesURL, withIntermediateDirectories: true)
+try fm.createDirectory(at: testsURL, withIntermediateDirectories: true)
+
+let data = try Data(contentsOf: schemaURL)
+let schema = try JSONDecoder().decode(Schema.self, from: data)
+
+for (rawName, def) in schema.defs {
+    let name = typeName(from: rawName)
+
+    var lines: [String] = []
+    if let desc = def.description {
+        for line in desc.split(separator: "\n") {
+            lines.append("/// \(line)")
+        }
+    }
+    lines.append("public struct \(name) {")
+    lines.append("}")
+    let source = lines.joined(separator: "\n") + "\n"
+    let sourceURL = sourcesURL.appendingPathComponent("\(name).swift")
+    try source.write(to: sourceURL, atomically: true, encoding: .utf8)
+
+    let testLines = [
+        "import XCTest",
+        "@testable import MIDI2",
+        "",
+        "final class \(name)Tests: XCTestCase {",
+        "    func testPlaceholder() {",
+        "        // TODO: Test \(name)",
+        "    }",
+        "}",
+        ""
+    ]
+    let testURL = testsURL.appendingPathComponent("\(name)Tests.swift")
+    try testLines.joined(separator: "\n").write(to: testURL, atomically: true, encoding: .utf8)
+}
+
+print("Generated \(schema.defs.count) definitions.")

--- a/Sources/MIDI2/ByteArray.swift
+++ b/Sources/MIDI2/ByteArray.swift
@@ -1,0 +1,2 @@
+public struct ByteArray {
+}

--- a/Sources/MIDI2/ClipEnvelope.swift
+++ b/Sources/MIDI2/ClipEnvelope.swift
@@ -1,0 +1,2 @@
+public struct ClipEnvelope {
+}

--- a/Sources/MIDI2/DataMessageBody.swift
+++ b/Sources/MIDI2/DataMessageBody.swift
@@ -1,0 +1,2 @@
+public struct DataMessageBody {
+}

--- a/Sources/MIDI2/DataMessageKind.swift
+++ b/Sources/MIDI2/DataMessageKind.swift
@@ -1,0 +1,2 @@
+public struct DataMessageKind {
+}

--- a/Sources/MIDI2/DeltaClockstampConfig.swift
+++ b/Sources/MIDI2/DeltaClockstampConfig.swift
@@ -1,0 +1,3 @@
+/// Clip configuration timing as used in MIDI Clip Files.
+public struct DeltaClockstampConfig {
+}

--- a/Sources/MIDI2/FlexChordName.swift
+++ b/Sources/MIDI2/FlexChordName.swift
@@ -1,0 +1,3 @@
+/// Flex: Chord name at position.
+public struct FlexChordName {
+}

--- a/Sources/MIDI2/FlexDataBody.swift
+++ b/Sources/MIDI2/FlexDataBody.swift
@@ -1,0 +1,2 @@
+public struct FlexDataBody {
+}

--- a/Sources/MIDI2/FlexKeySignature.swift
+++ b/Sources/MIDI2/FlexKeySignature.swift
@@ -1,0 +1,3 @@
+/// Flex: Set Key Signature (e.g., 'C', 'Gm').
+public struct FlexKeySignature {
+}

--- a/Sources/MIDI2/FlexLyric.swift
+++ b/Sources/MIDI2/FlexLyric.swift
@@ -1,0 +1,3 @@
+/// Flex Lyric.
+public struct FlexLyric {
+}

--- a/Sources/MIDI2/FlexMetronome.swift
+++ b/Sources/MIDI2/FlexMetronome.swift
@@ -1,0 +1,3 @@
+/// Flex: Set Metronome parameters.
+public struct FlexMetronome {
+}

--- a/Sources/MIDI2/FlexRuby.swift
+++ b/Sources/MIDI2/FlexRuby.swift
@@ -1,0 +1,3 @@
+/// Flex Ruby (furigana).
+public struct FlexRuby {
+}

--- a/Sources/MIDI2/FlexTempo.swift
+++ b/Sources/MIDI2/FlexTempo.swift
@@ -1,0 +1,3 @@
+/// Flex: Set Tempo (heuristic mapping to BPM).
+public struct FlexTempo {
+}

--- a/Sources/MIDI2/FlexText.swift
+++ b/Sources/MIDI2/FlexText.swift
@@ -1,0 +1,3 @@
+/// Flex Text.
+public struct FlexText {
+}

--- a/Sources/MIDI2/FlexTimeSignature.swift
+++ b/Sources/MIDI2/FlexTimeSignature.swift
@@ -1,0 +1,3 @@
+/// Flex: Set Time Signature (n / 2^d).
+public struct FlexTimeSignature {
+}

--- a/Sources/MIDI2/Group.swift
+++ b/Sources/MIDI2/Group.swift
@@ -1,0 +1,3 @@
+/// MIDI Group (0-15). Utility (0x0) and Stream (0xF) are groupless in v1.1+; set 0.
+public struct Group {
+}

--- a/Sources/MIDI2/Int32.swift
+++ b/Sources/MIDI2/Int32.swift
@@ -1,0 +1,2 @@
+public struct Int32 {
+}

--- a/Sources/MIDI2/Midi1ChannelVoiceBody.swift
+++ b/Sources/MIDI2/Midi1ChannelVoiceBody.swift
@@ -1,0 +1,3 @@
+/// Messages share this body, with relevant fields set based on status.
+public struct Midi1ChannelVoiceBody {
+}

--- a/Sources/MIDI2/Midi1StatusNibble.swift
+++ b/Sources/MIDI2/Midi1StatusNibble.swift
@@ -1,0 +1,3 @@
+/// 0x8..0xE
+public struct Midi1StatusNibble {
+}

--- a/Sources/MIDI2/Midi2AssignPerNoteController.swift
+++ b/Sources/MIDI2/Midi2AssignPerNoteController.swift
@@ -1,0 +1,2 @@
+public struct Midi2AssignPerNoteController {
+}

--- a/Sources/MIDI2/Midi2ChannelPressure.swift
+++ b/Sources/MIDI2/Midi2ChannelPressure.swift
@@ -1,0 +1,3 @@
+/// Status 0xD (Channel Pressure).
+public struct Midi2ChannelPressure {
+}

--- a/Sources/MIDI2/Midi2ChannelVoiceBody.swift
+++ b/Sources/MIDI2/Midi2ChannelVoiceBody.swift
@@ -1,0 +1,3 @@
+/// Only fields relevant to the specific status are present.
+public struct Midi2ChannelVoiceBody {
+}

--- a/Sources/MIDI2/Midi2ChannelVoiceVariants.swift
+++ b/Sources/MIDI2/Midi2ChannelVoiceVariants.swift
@@ -1,0 +1,2 @@
+public struct Midi2ChannelVoiceVariants {
+}

--- a/Sources/MIDI2/Midi2ControlChange.swift
+++ b/Sources/MIDI2/Midi2ControlChange.swift
@@ -1,0 +1,3 @@
+/// Status 0xB (CC).
+public struct Midi2ControlChange {
+}

--- a/Sources/MIDI2/Midi2NRPN.swift
+++ b/Sources/MIDI2/Midi2NRPN.swift
@@ -1,0 +1,3 @@
+/// Assignable Controller (absolute).
+public struct Midi2NRPN {
+}

--- a/Sources/MIDI2/Midi2NRPNRelative.swift
+++ b/Sources/MIDI2/Midi2NRPNRelative.swift
@@ -1,0 +1,3 @@
+/// Assignable Controller (relative).
+public struct Midi2NRPNRelative {
+}

--- a/Sources/MIDI2/Midi2NoteOff.swift
+++ b/Sources/MIDI2/Midi2NoteOff.swift
@@ -1,0 +1,3 @@
+/// Status 0x8 (Note Off).
+public struct Midi2NoteOff {
+}

--- a/Sources/MIDI2/Midi2NoteOn.swift
+++ b/Sources/MIDI2/Midi2NoteOn.swift
@@ -1,0 +1,3 @@
+/// Status 0x9 (Note On).
+public struct Midi2NoteOn {
+}

--- a/Sources/MIDI2/Midi2PerNoteManagement.swift
+++ b/Sources/MIDI2/Midi2PerNoteManagement.swift
@@ -1,0 +1,3 @@
+/// Per-Note Management (D/S flags).
+public struct Midi2PerNoteManagement {
+}

--- a/Sources/MIDI2/Midi2PitchBend.swift
+++ b/Sources/MIDI2/Midi2PitchBend.swift
@@ -1,0 +1,3 @@
+/// Status 0xE (Pitch Bend).
+public struct Midi2PitchBend {
+}

--- a/Sources/MIDI2/Midi2PolyPressure.swift
+++ b/Sources/MIDI2/Midi2PolyPressure.swift
@@ -1,0 +1,3 @@
+/// Status 0xA (Polyphonic Key Pressure).
+public struct Midi2PolyPressure {
+}

--- a/Sources/MIDI2/Midi2ProgramChange.swift
+++ b/Sources/MIDI2/Midi2ProgramChange.swift
@@ -1,0 +1,3 @@
+/// Status 0xC (Program Change).
+public struct Midi2ProgramChange {
+}

--- a/Sources/MIDI2/Midi2RPN.swift
+++ b/Sources/MIDI2/Midi2RPN.swift
@@ -1,0 +1,3 @@
+/// Registered Controller (absolute).
+public struct Midi2RPN {
+}

--- a/Sources/MIDI2/Midi2RPNRelative.swift
+++ b/Sources/MIDI2/Midi2RPNRelative.swift
@@ -1,0 +1,3 @@
+/// Registered Controller (relative).
+public struct Midi2RPNRelative {
+}

--- a/Sources/MIDI2/Midi2RegPerNoteController.swift
+++ b/Sources/MIDI2/Midi2RegPerNoteController.swift
@@ -1,0 +1,2 @@
+public struct Midi2RegPerNoteController {
+}

--- a/Sources/MIDI2/Midi2StatusNibble.swift
+++ b/Sources/MIDI2/Midi2StatusNibble.swift
@@ -1,0 +1,2 @@
+public struct Midi2StatusNibble {
+}

--- a/Sources/MIDI2/MidiCiAckNakBody.swift
+++ b/Sources/MIDI2/MidiCiAckNakBody.swift
@@ -1,0 +1,2 @@
+public struct MidiCiAckNakBody {
+}

--- a/Sources/MIDI2/MidiCiDiscoveryBody.swift
+++ b/Sources/MIDI2/MidiCiDiscoveryBody.swift
@@ -1,0 +1,2 @@
+public struct MidiCiDiscoveryBody {
+}

--- a/Sources/MIDI2/MidiCiEnvelope.swift
+++ b/Sources/MIDI2/MidiCiEnvelope.swift
@@ -1,0 +1,3 @@
+/// SysEx(7/8) payload for MIDI-CI transactions.
+public struct MidiCiEnvelope {
+}

--- a/Sources/MIDI2/MidiCiProcessInquiryBody.swift
+++ b/Sources/MIDI2/MidiCiProcessInquiryBody.swift
@@ -1,0 +1,2 @@
+public struct MidiCiProcessInquiryBody {
+}

--- a/Sources/MIDI2/MidiCiProfilesBody.swift
+++ b/Sources/MIDI2/MidiCiProfilesBody.swift
@@ -1,0 +1,2 @@
+public struct MidiCiProfilesBody {
+}

--- a/Sources/MIDI2/MidiCiPropertyExchangeBody.swift
+++ b/Sources/MIDI2/MidiCiPropertyExchangeBody.swift
@@ -1,0 +1,2 @@
+public struct MidiCiPropertyExchangeBody {
+}

--- a/Sources/MIDI2/NoteAttributeType.swift
+++ b/Sources/MIDI2/NoteAttributeType.swift
@@ -1,0 +1,2 @@
+public struct NoteAttributeType {
+}

--- a/Sources/MIDI2/StreamBody.swift
+++ b/Sources/MIDI2/StreamBody.swift
@@ -1,0 +1,3 @@
+/// Endpoint discovery, protocol selection, and FB info.
+public struct StreamBody {
+}

--- a/Sources/MIDI2/StreamOpcode.swift
+++ b/Sources/MIDI2/StreamOpcode.swift
@@ -1,0 +1,2 @@
+public struct StreamOpcode {
+}

--- a/Sources/MIDI2/SysEx7Body.swift
+++ b/Sources/MIDI2/SysEx7Body.swift
@@ -1,0 +1,3 @@
+/// 7-bit clean stream framed in 32-bit UMP words (up to 6 bytes per word).
+public struct SysEx7Body {
+}

--- a/Sources/MIDI2/SysEx7Packet.swift
+++ b/Sources/MIDI2/SysEx7Packet.swift
@@ -1,0 +1,2 @@
+public struct SysEx7Packet {
+}

--- a/Sources/MIDI2/SystemCommonRealtimeBody.swift
+++ b/Sources/MIDI2/SystemCommonRealtimeBody.swift
@@ -1,0 +1,3 @@
+/// UMP 0x1 System Common & Real-Time.
+public struct SystemCommonRealtimeBody {
+}

--- a/Sources/MIDI2/SystemStatus.swift
+++ b/Sources/MIDI2/SystemStatus.swift
@@ -1,0 +1,3 @@
+/// MIDI System Common/Real-Time per UMP.
+public struct SystemStatus {
+}

--- a/Sources/MIDI2/Uint14.swift
+++ b/Sources/MIDI2/Uint14.swift
@@ -1,0 +1,2 @@
+public struct Uint14 {
+}

--- a/Sources/MIDI2/Uint16.swift
+++ b/Sources/MIDI2/Uint16.swift
@@ -1,0 +1,2 @@
+public struct Uint16 {
+}

--- a/Sources/MIDI2/Uint21.swift
+++ b/Sources/MIDI2/Uint21.swift
@@ -1,0 +1,2 @@
+public struct Uint21 {
+}

--- a/Sources/MIDI2/Uint28.swift
+++ b/Sources/MIDI2/Uint28.swift
@@ -1,0 +1,2 @@
+public struct Uint28 {
+}

--- a/Sources/MIDI2/Uint32.swift
+++ b/Sources/MIDI2/Uint32.swift
@@ -1,0 +1,2 @@
+public struct Uint32 {
+}

--- a/Sources/MIDI2/Uint4.swift
+++ b/Sources/MIDI2/Uint4.swift
@@ -1,0 +1,2 @@
+public struct Uint4 {
+}

--- a/Sources/MIDI2/Uint7.swift
+++ b/Sources/MIDI2/Uint7.swift
@@ -1,0 +1,2 @@
+public struct Uint7 {
+}

--- a/Sources/MIDI2/Uint8.swift
+++ b/Sources/MIDI2/Uint8.swift
@@ -1,0 +1,2 @@
+public struct Uint8 {
+}

--- a/Sources/MIDI2/UmpHeader128.swift
+++ b/Sources/MIDI2/UmpHeader128.swift
@@ -1,0 +1,3 @@
+/// 128-bit UMP header for Data (SysEx8/MDS) and Flex Data.
+public struct UmpHeader128 {
+}

--- a/Sources/MIDI2/UmpHeader32.swift
+++ b/Sources/MIDI2/UmpHeader32.swift
@@ -1,0 +1,3 @@
+/// Common 32-bit UMP header (messageType + optional group).
+public struct UmpHeader32 {
+}

--- a/Sources/MIDI2/UmpHeader64.swift
+++ b/Sources/MIDI2/UmpHeader64.swift
@@ -1,0 +1,3 @@
+/// 64-bit UMP header for MIDI 2.0 Channel Voice.
+public struct UmpHeader64 {
+}

--- a/Sources/MIDI2/UmpMessageType.swift
+++ b/Sources/MIDI2/UmpMessageType.swift
@@ -1,0 +1,3 @@
+/// UMP Message Type nibble: 0=Utility,1=System,2=MIDI1 Ch Voice,3=SysEx7,4=MIDI2 Ch Voice,5=SysEx8/MDS,13=Flex,15=Stream.
+public struct UmpMessageType {
+}

--- a/Sources/MIDI2/UmpPacket128.swift
+++ b/Sources/MIDI2/UmpPacket128.swift
@@ -1,0 +1,2 @@
+public struct UmpPacket128 {
+}

--- a/Sources/MIDI2/UmpPacket32.swift
+++ b/Sources/MIDI2/UmpPacket32.swift
@@ -1,0 +1,2 @@
+public struct UmpPacket32 {
+}

--- a/Sources/MIDI2/UmpPacket64.swift
+++ b/Sources/MIDI2/UmpPacket64.swift
@@ -1,0 +1,2 @@
+public struct UmpPacket64 {
+}

--- a/Sources/MIDI2/UtilityBody.swift
+++ b/Sources/MIDI2/UtilityBody.swift
@@ -1,0 +1,3 @@
+/// UMP Type 0x0 Utility messages (groupless).
+public struct UtilityBody {
+}

--- a/Sources/MIDI2/UtilityOpcode.swift
+++ b/Sources/MIDI2/UtilityOpcode.swift
@@ -1,0 +1,3 @@
+/// 0=NOOP,1=JR Clock,2=JR Timestamp
+public struct UtilityOpcode {
+}

--- a/Sources/MIDI2CI/Placeholder.swift
+++ b/Sources/MIDI2CI/Placeholder.swift
@@ -1,0 +1,1 @@
+public struct MIDI2CIPlaceholder {}

--- a/Tests/MIDI2Tests/ByteArrayTests.swift
+++ b/Tests/MIDI2Tests/ByteArrayTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class ByteArrayTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test ByteArray
+    }
+}

--- a/Tests/MIDI2Tests/ClipEnvelopeTests.swift
+++ b/Tests/MIDI2Tests/ClipEnvelopeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class ClipEnvelopeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test ClipEnvelope
+    }
+}

--- a/Tests/MIDI2Tests/DataMessageBodyTests.swift
+++ b/Tests/MIDI2Tests/DataMessageBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class DataMessageBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test DataMessageBody
+    }
+}

--- a/Tests/MIDI2Tests/DataMessageKindTests.swift
+++ b/Tests/MIDI2Tests/DataMessageKindTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class DataMessageKindTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test DataMessageKind
+    }
+}

--- a/Tests/MIDI2Tests/DeltaClockstampConfigTests.swift
+++ b/Tests/MIDI2Tests/DeltaClockstampConfigTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class DeltaClockstampConfigTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test DeltaClockstampConfig
+    }
+}

--- a/Tests/MIDI2Tests/FlexChordNameTests.swift
+++ b/Tests/MIDI2Tests/FlexChordNameTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexChordNameTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexChordName
+    }
+}

--- a/Tests/MIDI2Tests/FlexDataBodyTests.swift
+++ b/Tests/MIDI2Tests/FlexDataBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexDataBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexDataBody
+    }
+}

--- a/Tests/MIDI2Tests/FlexKeySignatureTests.swift
+++ b/Tests/MIDI2Tests/FlexKeySignatureTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexKeySignatureTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexKeySignature
+    }
+}

--- a/Tests/MIDI2Tests/FlexLyricTests.swift
+++ b/Tests/MIDI2Tests/FlexLyricTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexLyricTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexLyric
+    }
+}

--- a/Tests/MIDI2Tests/FlexMetronomeTests.swift
+++ b/Tests/MIDI2Tests/FlexMetronomeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexMetronomeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexMetronome
+    }
+}

--- a/Tests/MIDI2Tests/FlexRubyTests.swift
+++ b/Tests/MIDI2Tests/FlexRubyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexRubyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexRuby
+    }
+}

--- a/Tests/MIDI2Tests/FlexTempoTests.swift
+++ b/Tests/MIDI2Tests/FlexTempoTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexTempoTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexTempo
+    }
+}

--- a/Tests/MIDI2Tests/FlexTextTests.swift
+++ b/Tests/MIDI2Tests/FlexTextTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexTextTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexText
+    }
+}

--- a/Tests/MIDI2Tests/FlexTimeSignatureTests.swift
+++ b/Tests/MIDI2Tests/FlexTimeSignatureTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexTimeSignatureTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test FlexTimeSignature
+    }
+}

--- a/Tests/MIDI2Tests/GroupTests.swift
+++ b/Tests/MIDI2Tests/GroupTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class GroupTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Group
+    }
+}

--- a/Tests/MIDI2Tests/Int32Tests.swift
+++ b/Tests/MIDI2Tests/Int32Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Int32Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Int32
+    }
+}

--- a/Tests/MIDI2Tests/Midi1ChannelVoiceBodyTests.swift
+++ b/Tests/MIDI2Tests/Midi1ChannelVoiceBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi1ChannelVoiceBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi1ChannelVoiceBody
+    }
+}

--- a/Tests/MIDI2Tests/Midi1StatusNibbleTests.swift
+++ b/Tests/MIDI2Tests/Midi1StatusNibbleTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi1StatusNibbleTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi1StatusNibble
+    }
+}

--- a/Tests/MIDI2Tests/Midi2AssignPerNoteControllerTests.swift
+++ b/Tests/MIDI2Tests/Midi2AssignPerNoteControllerTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2AssignPerNoteControllerTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2AssignPerNoteController
+    }
+}

--- a/Tests/MIDI2Tests/Midi2ChannelPressureTests.swift
+++ b/Tests/MIDI2Tests/Midi2ChannelPressureTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2ChannelPressureTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2ChannelPressure
+    }
+}

--- a/Tests/MIDI2Tests/Midi2ChannelVoiceBodyTests.swift
+++ b/Tests/MIDI2Tests/Midi2ChannelVoiceBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2ChannelVoiceBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2ChannelVoiceBody
+    }
+}

--- a/Tests/MIDI2Tests/Midi2ChannelVoiceVariantsTests.swift
+++ b/Tests/MIDI2Tests/Midi2ChannelVoiceVariantsTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2ChannelVoiceVariantsTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2ChannelVoiceVariants
+    }
+}

--- a/Tests/MIDI2Tests/Midi2ControlChangeTests.swift
+++ b/Tests/MIDI2Tests/Midi2ControlChangeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2ControlChangeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2ControlChange
+    }
+}

--- a/Tests/MIDI2Tests/Midi2NRPNRelativeTests.swift
+++ b/Tests/MIDI2Tests/Midi2NRPNRelativeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2NRPNRelativeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2NRPNRelative
+    }
+}

--- a/Tests/MIDI2Tests/Midi2NRPNTests.swift
+++ b/Tests/MIDI2Tests/Midi2NRPNTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2NRPNTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2NRPN
+    }
+}

--- a/Tests/MIDI2Tests/Midi2NoteOffTests.swift
+++ b/Tests/MIDI2Tests/Midi2NoteOffTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2NoteOffTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2NoteOff
+    }
+}

--- a/Tests/MIDI2Tests/Midi2NoteOnTests.swift
+++ b/Tests/MIDI2Tests/Midi2NoteOnTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2NoteOnTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2NoteOn
+    }
+}

--- a/Tests/MIDI2Tests/Midi2PerNoteManagementTests.swift
+++ b/Tests/MIDI2Tests/Midi2PerNoteManagementTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2PerNoteManagementTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2PerNoteManagement
+    }
+}

--- a/Tests/MIDI2Tests/Midi2PitchBendTests.swift
+++ b/Tests/MIDI2Tests/Midi2PitchBendTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2PitchBendTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2PitchBend
+    }
+}

--- a/Tests/MIDI2Tests/Midi2PolyPressureTests.swift
+++ b/Tests/MIDI2Tests/Midi2PolyPressureTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2PolyPressureTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2PolyPressure
+    }
+}

--- a/Tests/MIDI2Tests/Midi2ProgramChangeTests.swift
+++ b/Tests/MIDI2Tests/Midi2ProgramChangeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2ProgramChangeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2ProgramChange
+    }
+}

--- a/Tests/MIDI2Tests/Midi2RPNRelativeTests.swift
+++ b/Tests/MIDI2Tests/Midi2RPNRelativeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2RPNRelativeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2RPNRelative
+    }
+}

--- a/Tests/MIDI2Tests/Midi2RPNTests.swift
+++ b/Tests/MIDI2Tests/Midi2RPNTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2RPNTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2RPN
+    }
+}

--- a/Tests/MIDI2Tests/Midi2RegPerNoteControllerTests.swift
+++ b/Tests/MIDI2Tests/Midi2RegPerNoteControllerTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2RegPerNoteControllerTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2RegPerNoteController
+    }
+}

--- a/Tests/MIDI2Tests/Midi2StatusNibbleTests.swift
+++ b/Tests/MIDI2Tests/Midi2StatusNibbleTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2StatusNibbleTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Midi2StatusNibble
+    }
+}

--- a/Tests/MIDI2Tests/MidiCiAckNakBodyTests.swift
+++ b/Tests/MIDI2Tests/MidiCiAckNakBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class MidiCiAckNakBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test MidiCiAckNakBody
+    }
+}

--- a/Tests/MIDI2Tests/MidiCiDiscoveryBodyTests.swift
+++ b/Tests/MIDI2Tests/MidiCiDiscoveryBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class MidiCiDiscoveryBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test MidiCiDiscoveryBody
+    }
+}

--- a/Tests/MIDI2Tests/MidiCiEnvelopeTests.swift
+++ b/Tests/MIDI2Tests/MidiCiEnvelopeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class MidiCiEnvelopeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test MidiCiEnvelope
+    }
+}

--- a/Tests/MIDI2Tests/MidiCiProcessInquiryBodyTests.swift
+++ b/Tests/MIDI2Tests/MidiCiProcessInquiryBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class MidiCiProcessInquiryBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test MidiCiProcessInquiryBody
+    }
+}

--- a/Tests/MIDI2Tests/MidiCiProfilesBodyTests.swift
+++ b/Tests/MIDI2Tests/MidiCiProfilesBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class MidiCiProfilesBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test MidiCiProfilesBody
+    }
+}

--- a/Tests/MIDI2Tests/MidiCiPropertyExchangeBodyTests.swift
+++ b/Tests/MIDI2Tests/MidiCiPropertyExchangeBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class MidiCiPropertyExchangeBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test MidiCiPropertyExchangeBody
+    }
+}

--- a/Tests/MIDI2Tests/NoteAttributeTypeTests.swift
+++ b/Tests/MIDI2Tests/NoteAttributeTypeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class NoteAttributeTypeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test NoteAttributeType
+    }
+}

--- a/Tests/MIDI2Tests/StreamBodyTests.swift
+++ b/Tests/MIDI2Tests/StreamBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class StreamBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test StreamBody
+    }
+}

--- a/Tests/MIDI2Tests/StreamOpcodeTests.swift
+++ b/Tests/MIDI2Tests/StreamOpcodeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class StreamOpcodeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test StreamOpcode
+    }
+}

--- a/Tests/MIDI2Tests/SysEx7BodyTests.swift
+++ b/Tests/MIDI2Tests/SysEx7BodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class SysEx7BodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test SysEx7Body
+    }
+}

--- a/Tests/MIDI2Tests/SysEx7PacketTests.swift
+++ b/Tests/MIDI2Tests/SysEx7PacketTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class SysEx7PacketTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test SysEx7Packet
+    }
+}

--- a/Tests/MIDI2Tests/SystemCommonRealtimeBodyTests.swift
+++ b/Tests/MIDI2Tests/SystemCommonRealtimeBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class SystemCommonRealtimeBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test SystemCommonRealtimeBody
+    }
+}

--- a/Tests/MIDI2Tests/SystemStatusTests.swift
+++ b/Tests/MIDI2Tests/SystemStatusTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class SystemStatusTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test SystemStatus
+    }
+}

--- a/Tests/MIDI2Tests/Uint14Tests.swift
+++ b/Tests/MIDI2Tests/Uint14Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Uint14Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Uint14
+    }
+}

--- a/Tests/MIDI2Tests/Uint16Tests.swift
+++ b/Tests/MIDI2Tests/Uint16Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Uint16Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Uint16
+    }
+}

--- a/Tests/MIDI2Tests/Uint21Tests.swift
+++ b/Tests/MIDI2Tests/Uint21Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Uint21Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Uint21
+    }
+}

--- a/Tests/MIDI2Tests/Uint28Tests.swift
+++ b/Tests/MIDI2Tests/Uint28Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Uint28Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Uint28
+    }
+}

--- a/Tests/MIDI2Tests/Uint32Tests.swift
+++ b/Tests/MIDI2Tests/Uint32Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Uint32Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Uint32
+    }
+}

--- a/Tests/MIDI2Tests/Uint4Tests.swift
+++ b/Tests/MIDI2Tests/Uint4Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Uint4Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Uint4
+    }
+}

--- a/Tests/MIDI2Tests/Uint7Tests.swift
+++ b/Tests/MIDI2Tests/Uint7Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Uint7Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Uint7
+    }
+}

--- a/Tests/MIDI2Tests/Uint8Tests.swift
+++ b/Tests/MIDI2Tests/Uint8Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class Uint8Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test Uint8
+    }
+}

--- a/Tests/MIDI2Tests/UmpHeader128Tests.swift
+++ b/Tests/MIDI2Tests/UmpHeader128Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UmpHeader128Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UmpHeader128
+    }
+}

--- a/Tests/MIDI2Tests/UmpHeader32Tests.swift
+++ b/Tests/MIDI2Tests/UmpHeader32Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UmpHeader32Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UmpHeader32
+    }
+}

--- a/Tests/MIDI2Tests/UmpHeader64Tests.swift
+++ b/Tests/MIDI2Tests/UmpHeader64Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UmpHeader64Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UmpHeader64
+    }
+}

--- a/Tests/MIDI2Tests/UmpMessageTypeTests.swift
+++ b/Tests/MIDI2Tests/UmpMessageTypeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UmpMessageTypeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UmpMessageType
+    }
+}

--- a/Tests/MIDI2Tests/UmpPacket128Tests.swift
+++ b/Tests/MIDI2Tests/UmpPacket128Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UmpPacket128Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UmpPacket128
+    }
+}

--- a/Tests/MIDI2Tests/UmpPacket32Tests.swift
+++ b/Tests/MIDI2Tests/UmpPacket32Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UmpPacket32Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UmpPacket32
+    }
+}

--- a/Tests/MIDI2Tests/UmpPacket64Tests.swift
+++ b/Tests/MIDI2Tests/UmpPacket64Tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UmpPacket64Tests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UmpPacket64
+    }
+}

--- a/Tests/MIDI2Tests/UtilityBodyTests.swift
+++ b/Tests/MIDI2Tests/UtilityBodyTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UtilityBodyTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UtilityBody
+    }
+}

--- a/Tests/MIDI2Tests/UtilityOpcodeTests.swift
+++ b/Tests/MIDI2Tests/UtilityOpcodeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MIDI2
+
+final class UtilityOpcodeTests: XCTestCase {
+    func testPlaceholder() {
+        // TODO: Test UtilityOpcode
+    }
+}


### PR DESCRIPTION
## Summary
- add SchemaGen utility parsing `midi2.full.closed.schema.json`
- generate Swift type skeletons with doc comments for all `$defs`
- stub out matching XCTest placeholders

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689c106642788333aca21d24414937e4