### PR TITLE
Implement Universal Packet structures and tests

### DIFF
--- a/Sources/MIDI2/Ump128.swift
+++ b/Sources/MIDI2/Ump128.swift
@@ -1,0 +1,51 @@
+/// A 128-bit Universal MIDI Packet (four 32-bit words).
+public struct Ump128: UniversalPacket {
+    public static let wordCount = 4
+
+    public var word0: UInt32
+    public var word1: UInt32
+    public var word2: UInt32
+    public var word3: UInt32
+
+    /// Creates a packet from four 32-bit words.
+    public init?(word0: UInt32, word1: UInt32, word2: UInt32, word3: UInt32) {
+        self.word0 = word0
+        self.word1 = word1
+        self.word2 = word2
+        self.word3 = word3
+    }
+
+    /// Creates a packet from an array of words. Fails if count is not 4.
+    public init?(words: [UInt32]) {
+        guard words.count == Self.wordCount else { return nil }
+        self.word0 = words[0]
+        self.word1 = words[1]
+        self.word2 = words[2]
+        self.word3 = words[3]
+    }
+
+    /// The raw words composing the packet.
+    public var words: [UInt32] { [word0, word1, word2, word3] }
+}
+
+public extension Ump128 {
+    /// Status from the first word (bits 23-16).
+    var status: UInt8 { UInt8((word0 >> 16) & 0xFF) }
+    /// Remaining bytes in order (byte3..byte16).
+    var payloadBytes: [UInt8] {
+        [UInt8((word0 >> 8) & 0xFF),
+         UInt8(word0 & 0xFF),
+         UInt8((word1 >> 24) & 0xFF),
+         UInt8((word1 >> 16) & 0xFF),
+         UInt8((word1 >> 8) & 0xFF),
+         UInt8(word1 & 0xFF),
+         UInt8((word2 >> 24) & 0xFF),
+         UInt8((word2 >> 16) & 0xFF),
+         UInt8((word2 >> 8) & 0xFF),
+         UInt8(word2 & 0xFF),
+         UInt8((word3 >> 24) & 0xFF),
+         UInt8((word3 >> 16) & 0xFF),
+         UInt8((word3 >> 8) & 0xFF),
+         UInt8(word3 & 0xFF)]
+    }
+}

--- a/Sources/MIDI2/Ump64.swift
+++ b/Sources/MIDI2/Ump64.swift
@@ -1,0 +1,37 @@
+/// A 64-bit Universal MIDI Packet (two 32-bit words).
+public struct Ump64: UniversalPacket {
+    public static let wordCount = 2
+
+    public var word0: UInt32
+    public var word1: UInt32
+
+    /// Creates a packet from two 32-bit words.
+    public init?(word0: UInt32, word1: UInt32) {
+        self.word0 = word0
+        self.word1 = word1
+    }
+
+    /// Creates a packet from an array of words. Fails if count is not 2.
+    public init?(words: [UInt32]) {
+        guard words.count == Self.wordCount else { return nil }
+        self.word0 = words[0]
+        self.word1 = words[1]
+    }
+
+    /// The raw words composing the packet.
+    public var words: [UInt32] { [word0, word1] }
+}
+
+public extension Ump64 {
+    /// Status from the first word (bits 23-16).
+    var status: UInt8 { UInt8((word0 >> 16) & 0xFF) }
+    /// Remaining bytes in order (byte3..byte8).
+    var payloadBytes: [UInt8] {
+        [UInt8((word0 >> 8) & 0xFF),
+         UInt8(word0 & 0xFF),
+         UInt8((word1 >> 24) & 0xFF),
+         UInt8((word1 >> 16) & 0xFF),
+         UInt8((word1 >> 8) & 0xFF),
+         UInt8(word1 & 0xFF)]
+    }
+}

--- a/Sources/MIDI2/Ump96.swift
+++ b/Sources/MIDI2/Ump96.swift
@@ -1,0 +1,44 @@
+/// A 96-bit Universal MIDI Packet (three 32-bit words).
+public struct Ump96: UniversalPacket {
+    public static let wordCount = 3
+
+    public var word0: UInt32
+    public var word1: UInt32
+    public var word2: UInt32
+
+    /// Creates a packet from three 32-bit words.
+    public init?(word0: UInt32, word1: UInt32, word2: UInt32) {
+        self.word0 = word0
+        self.word1 = word1
+        self.word2 = word2
+    }
+
+    /// Creates a packet from an array of words. Fails if count is not 3.
+    public init?(words: [UInt32]) {
+        guard words.count == Self.wordCount else { return nil }
+        self.word0 = words[0]
+        self.word1 = words[1]
+        self.word2 = words[2]
+    }
+
+    /// The raw words composing the packet.
+    public var words: [UInt32] { [word0, word1, word2] }
+}
+
+public extension Ump96 {
+    /// Status from the first word (bits 23-16).
+    var status: UInt8 { UInt8((word0 >> 16) & 0xFF) }
+    /// Remaining bytes in order (byte3..byte12).
+    var payloadBytes: [UInt8] {
+        [UInt8((word0 >> 8) & 0xFF),
+         UInt8(word0 & 0xFF),
+         UInt8((word1 >> 24) & 0xFF),
+         UInt8((word1 >> 16) & 0xFF),
+         UInt8((word1 >> 8) & 0xFF),
+         UInt8(word1 & 0xFF),
+         UInt8((word2 >> 24) & 0xFF),
+         UInt8((word2 >> 16) & 0xFF),
+         UInt8((word2 >> 8) & 0xFF),
+         UInt8(word2 & 0xFF)]
+    }
+}

--- a/Sources/MIDI2/UniversalPacket.swift
+++ b/Sources/MIDI2/UniversalPacket.swift
@@ -1,0 +1,48 @@
+public protocol UniversalPacket {
+    /// Number of 32-bit words in this packet.
+    static var wordCount: Int { get }
+    /// Initialize from raw 32-bit words. Fails if word count is incorrect.
+    init?(words: [UInt32])
+    /// Raw 32-bit words representing the packet.
+    var words: [UInt32] { get }
+}
+
+public extension UniversalPacket {
+    /// Number of bytes in this packet.
+    static var byteCount: Int { wordCount * 4 }
+
+    /// Initialize from raw bytes. Fails if byte count is incorrect.
+    init?(rawBytes: [UInt8]) {
+        guard rawBytes.count == Self.byteCount else { return nil }
+        var words: [UInt32] = []
+        words.reserveCapacity(Self.wordCount)
+        for i in stride(from: 0, to: rawBytes.count, by: 4) {
+            let word = UInt32(rawBytes[i]) << 24 |
+                       UInt32(rawBytes[i+1]) << 16 |
+                       UInt32(rawBytes[i+2]) << 8 |
+                       UInt32(rawBytes[i+3])
+            words.append(word)
+        }
+        self.init(words: words)
+    }
+
+    /// Raw bytes of the packet in big-endian order.
+    var rawBytes: [UInt8] {
+        words.flatMap { word in
+            [UInt8((word >> 24) & 0xFF),
+             UInt8((word >> 16) & 0xFF),
+             UInt8((word >> 8) & 0xFF),
+             UInt8(word & 0xFF)]
+        }
+    }
+
+    /// Message Type from the first 32-bit word (bits 31-28).
+    var messageType: UInt8 {
+        UInt8((words[0] >> 28) & 0xF)
+    }
+
+    /// Group from the first 32-bit word (bits 27-24).
+    var group: UInt8 {
+        UInt8((words[0] >> 24) & 0xF)
+    }
+}

--- a/Tests/MIDI2Tests/UmpPacketsTests.swift
+++ b/Tests/MIDI2Tests/UmpPacketsTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import MIDI2
+
+final class UmpPacketsTests: XCTestCase {
+    func testUmp64RoundTrip() {
+        let words: [UInt32] = [0x12345678, 0x9ABCDEF0]
+        guard let packet = Ump64(words: words) else {
+            XCTFail("Failed to create Ump64")
+            return
+        }
+        XCTAssertEqual(packet.messageType, 0x1)
+        XCTAssertEqual(packet.group, 0x2)
+        XCTAssertEqual(packet.words, words)
+        let bytes = packet.rawBytes
+        XCTAssertEqual(bytes, [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0])
+        let decoded = Ump64(rawBytes: bytes)
+        XCTAssertEqual(decoded?.words, words)
+    }
+
+    func testUmp96RoundTrip() {
+        let words: [UInt32] = [0x12345678, 0x9ABCDEF0, 0x01020304]
+        guard let packet = Ump96(words: words) else {
+            XCTFail("Failed to create Ump96")
+            return
+        }
+        XCTAssertEqual(packet.messageType, 0x1)
+        XCTAssertEqual(packet.group, 0x2)
+        XCTAssertEqual(packet.words, words)
+        let bytes = packet.rawBytes
+        XCTAssertEqual(bytes, [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x01, 0x02, 0x03, 0x04])
+        let decoded = Ump96(rawBytes: bytes)
+        XCTAssertEqual(decoded?.words, words)
+    }
+
+    func testUmp128RoundTrip() {
+        let words: [UInt32] = [0x12345678, 0x9ABCDEF0, 0x01020304, 0x55667788]
+        guard let packet = Ump128(words: words) else {
+            XCTFail("Failed to create Ump128")
+            return
+        }
+        XCTAssertEqual(packet.messageType, 0x1)
+        XCTAssertEqual(packet.group, 0x2)
+        XCTAssertEqual(packet.words, words)
+        let bytes = packet.rawBytes
+        XCTAssertEqual(bytes, [0x12, 0x34, 0x56, 0x78,
+                               0x9A, 0xBC, 0xDE, 0xF0,
+                               0x01, 0x02, 0x03, 0x04,
+                               0x55, 0x66, 0x77, 0x88])
+        let decoded = Ump128(rawBytes: bytes)
+        XCTAssertEqual(decoded?.words, words)
+    }
+
+    func testMalformedPackets() {
+        // too few bytes
+        XCTAssertNil(Ump64(rawBytes: [0x00, 0x01]))
+        XCTAssertNil(Ump96(rawBytes: Array(repeating: 0x00, count: 8)))
+        XCTAssertNil(Ump128(rawBytes: Array(repeating: 0x00, count: 12)))
+    }
+}


### PR DESCRIPTION
## Summary
- add `UniversalPacket` protocol with byte/word encoding helpers
- implement `Ump64`, `Ump96`, and `Ump128` packet structs with bit-field accessors
- add round-trip and malformed packet tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689c11d7011c8333b56f858564153c9f