### PR TITLE
Implement Channel Voice message structs with encoding and tests

### DIFF
--- a/Sources/MIDI2/ChannelVoice/ControlChange.swift
+++ b/Sources/MIDI2/ChannelVoice/ControlChange.swift
@@ -1,0 +1,41 @@
+public struct ControlChange: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let control: Uint7
+    public let value: UInt32
+
+    public init(group: Uint4, channel: Uint4, control: Uint7, value: UInt32) {
+        self.group = group
+        self.channel = channel
+        self.control = control
+        self.value = value
+    }
+
+    public func ump() -> Ump64 {
+        let byte0 = UInt32(0x4 << 4 | group.rawValue)
+        let byte1 = UInt32(0xB << 4 | channel.rawValue)
+        let byte2 = UInt32(control.rawValue)
+        let byte3 = UInt32(0)
+        let word0 = (byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3
+        let byte4 = UInt32((value >> 24) & 0xFF)
+        let byte5 = UInt32((value >> 16) & 0xFF)
+        let byte6 = UInt32((value >> 8) & 0xFF)
+        let byte7 = UInt32(value & 0xFF)
+        let word1 = (byte4 << 24) | (byte5 << 16) | (byte6 << 8) | byte7
+        return Ump64(word0: word0, word1: word1)!
+    }
+
+    public init?(ump: Ump64) {
+        let mt = UInt8((ump.word0 >> 28) & 0xF)
+        guard mt == 0x4 else { return nil }
+        let byte0 = UInt8((ump.word0 >> 24) & 0xFF)
+        guard let group = Uint4(byte0 & 0x0F) else { return nil }
+        let byte1 = UInt8((ump.word0 >> 16) & 0xFF)
+        let status = byte1 >> 4
+        guard status == 0xB, let channel = Uint4(byte1 & 0x0F) else { return nil }
+        let byte2 = UInt8((ump.word0 >> 8) & 0xFF)
+        guard let control = Uint7(byte2) else { return nil }
+        let value = ump.word1
+        self.init(group: group, channel: channel, control: control, value: value)
+    }
+}

--- a/Sources/MIDI2/ChannelVoice/NoteOff.swift
+++ b/Sources/MIDI2/ChannelVoice/NoteOff.swift
@@ -1,0 +1,52 @@
+public struct NoteOff: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let noteNumber: Uint7
+    public let velocity: UInt16
+    public let attributeType: NoteAttributeType
+    public let attributeData: UInt16
+
+    public init(group: Uint4, channel: Uint4, noteNumber: Uint7, velocity: UInt16, attributeType: NoteAttributeType = .none, attributeData: UInt16 = 0) {
+        self.group = group
+        self.channel = channel
+        self.noteNumber = noteNumber
+        self.velocity = velocity
+        self.attributeType = attributeType
+        self.attributeData = attributeData
+    }
+
+    public func ump() -> Ump64 {
+        let byte0 = UInt32(0x4 << 4 | group.rawValue)
+        let byte1 = UInt32(0x8 << 4 | channel.rawValue)
+        let byte2 = UInt32(noteNumber.rawValue)
+        let byte3 = UInt32(attributeType.rawValue)
+        let word0 = (byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3
+        let byte4 = UInt32(velocity >> 8)
+        let byte5 = UInt32(velocity & 0xFF)
+        let byte6 = UInt32(attributeData >> 8)
+        let byte7 = UInt32(attributeData & 0xFF)
+        let word1 = (byte4 << 24) | (byte5 << 16) | (byte6 << 8) | byte7
+        return Ump64(word0: word0, word1: word1)!
+    }
+
+    public init?(ump: Ump64) {
+        let mt = UInt8((ump.word0 >> 28) & 0xF)
+        guard mt == 0x4 else { return nil }
+        let byte0 = UInt8((ump.word0 >> 24) & 0xFF)
+        guard let group = Uint4(byte0 & 0x0F) else { return nil }
+        let byte1 = UInt8((ump.word0 >> 16) & 0xFF)
+        let status = byte1 >> 4
+        guard status == 0x8, let channel = Uint4(byte1 & 0x0F) else { return nil }
+        let byte2 = UInt8((ump.word0 >> 8) & 0xFF)
+        guard let noteNumber = Uint7(byte2) else { return nil }
+        let byte3 = UInt8(ump.word0 & 0xFF)
+        let attributeType = NoteAttributeType(byte3)
+        let byte4 = UInt8((ump.word1 >> 24) & 0xFF)
+        let byte5 = UInt8((ump.word1 >> 16) & 0xFF)
+        let byte6 = UInt8((ump.word1 >> 8) & 0xFF)
+        let byte7 = UInt8(ump.word1 & 0xFF)
+        let velocity = UInt16(byte4) << 8 | UInt16(byte5)
+        let attributeData = UInt16(byte6) << 8 | UInt16(byte7)
+        self.init(group: group, channel: channel, noteNumber: noteNumber, velocity: velocity, attributeType: attributeType, attributeData: attributeData)
+    }
+}

--- a/Sources/MIDI2/ChannelVoice/PitchBend.swift
+++ b/Sources/MIDI2/ChannelVoice/PitchBend.swift
@@ -1,0 +1,37 @@
+public struct PitchBend: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let value: UInt32
+
+    public init(group: Uint4, channel: Uint4, value: UInt32) {
+        self.group = group
+        self.channel = channel
+        self.value = value
+    }
+
+    public func ump() -> Ump64 {
+        let byte0 = UInt32(0x4 << 4 | group.rawValue)
+        let byte1 = UInt32(0xE << 4 | channel.rawValue)
+        let byte2: UInt32 = 0
+        let byte3: UInt32 = 0
+        let word0 = (byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3
+        let byte4 = UInt32((value >> 24) & 0xFF)
+        let byte5 = UInt32((value >> 16) & 0xFF)
+        let byte6 = UInt32((value >> 8) & 0xFF)
+        let byte7 = UInt32(value & 0xFF)
+        let word1 = (byte4 << 24) | (byte5 << 16) | (byte6 << 8) | byte7
+        return Ump64(word0: word0, word1: word1)!
+    }
+
+    public init?(ump: Ump64) {
+        let mt = UInt8((ump.word0 >> 28) & 0xF)
+        guard mt == 0x4 else { return nil }
+        let byte0 = UInt8((ump.word0 >> 24) & 0xFF)
+        guard let group = Uint4(byte0 & 0x0F) else { return nil }
+        let byte1 = UInt8((ump.word0 >> 16) & 0xFF)
+        let status = byte1 >> 4
+        guard status == 0xE, let channel = Uint4(byte1 & 0x0F) else { return nil }
+        let value = ump.word1
+        self.init(group: group, channel: channel, value: value)
+    }
+}

--- a/Sources/MIDI2/ChannelVoice/PolyPressure.swift
+++ b/Sources/MIDI2/ChannelVoice/PolyPressure.swift
@@ -1,0 +1,42 @@
+public struct PolyPressure: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let noteNumber: Uint7
+    public let pressure: UInt32
+
+    public init(group: Uint4, channel: Uint4, noteNumber: Uint7, pressure: UInt32) {
+        self.group = group
+        self.channel = channel
+        self.noteNumber = noteNumber
+        self.pressure = pressure
+    }
+
+    public func ump() -> Ump64 {
+        let byte0 = UInt32(0x4 << 4 | group.rawValue)
+        let byte1 = UInt32(0xA << 4 | channel.rawValue)
+        let byte2 = UInt32(noteNumber.rawValue)
+        let byte3 = UInt32(0)
+        let word0 = (byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3
+        let byte4 = UInt32((pressure >> 24) & 0xFF)
+        let byte5 = UInt32((pressure >> 16) & 0xFF)
+        let byte6 = UInt32((pressure >> 8) & 0xFF)
+        let byte7 = UInt32(pressure & 0xFF)
+        let word1 = (byte4 << 24) | (byte5 << 16) | (byte6 << 8) | byte7
+        return Ump64(word0: word0, word1: word1)!
+    }
+
+    public init?(ump: Ump64) {
+        let mt = UInt8((ump.word0 >> 28) & 0xF)
+        guard mt == 0x4 else { return nil }
+        let byte0 = UInt8((ump.word0 >> 24) & 0xFF)
+        guard let group = Uint4(byte0 & 0x0F) else { return nil }
+        let byte1 = UInt8((ump.word0 >> 16) & 0xFF)
+        let status = byte1 >> 4
+        guard status == 0xA, let channel = Uint4(byte1 & 0x0F) else { return nil }
+        let byte2 = UInt8((ump.word0 >> 8) & 0xFF)
+        guard let noteNumber = Uint7(byte2) else { return nil }
+        let byte4 = UInt32(ump.word1)
+        let pressure = byte4
+        self.init(group: group, channel: channel, noteNumber: noteNumber, pressure: pressure)
+    }
+}

--- a/Sources/MIDI2/ChannelVoice/ProgramChange.swift
+++ b/Sources/MIDI2/ChannelVoice/ProgramChange.swift
@@ -1,0 +1,50 @@
+public struct ProgramChange: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let program: Uint7
+    public let bankMsb: Uint7?
+    public let bankLsb: Uint7?
+    public let bankValid: Bool
+
+    public init(group: Uint4, channel: Uint4, program: Uint7, bankMsb: Uint7? = nil, bankLsb: Uint7? = nil) {
+        self.group = group
+        self.channel = channel
+        self.program = program
+        self.bankMsb = bankMsb
+        self.bankLsb = bankLsb
+        self.bankValid = bankMsb != nil || bankLsb != nil
+    }
+
+    public func ump() -> Ump64 {
+        let byte0 = UInt32(0x4 << 4 | group.rawValue)
+        let byte1 = UInt32(0xC << 4 | channel.rawValue)
+        let byte2 = UInt32(program.rawValue)
+        let byte3 = UInt32(bankValid ? 0x80 : 0x00)
+        let word0 = (byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3
+        let byte4 = UInt32(bankMsb?.rawValue ?? 0)
+        let byte5 = UInt32(bankLsb?.rawValue ?? 0)
+        let byte6: UInt32 = 0
+        let byte7: UInt32 = 0
+        let word1 = (byte4 << 24) | (byte5 << 16) | (byte6 << 8) | byte7
+        return Ump64(word0: word0, word1: word1)!
+    }
+
+    public init?(ump: Ump64) {
+        let mt = UInt8((ump.word0 >> 28) & 0xF)
+        guard mt == 0x4 else { return nil }
+        let byte0 = UInt8((ump.word0 >> 24) & 0xFF)
+        guard let group = Uint4(byte0 & 0x0F) else { return nil }
+        let byte1 = UInt8((ump.word0 >> 16) & 0xFF)
+        let status = byte1 >> 4
+        guard status == 0xC, let channel = Uint4(byte1 & 0x0F) else { return nil }
+        let byte2 = UInt8((ump.word0 >> 8) & 0xFF)
+        guard let program = Uint7(byte2) else { return nil }
+        let byte3 = UInt8(ump.word0 & 0xFF)
+        let bankValid = (byte3 & 0x80) != 0
+        let byte4 = UInt8((ump.word1 >> 24) & 0xFF)
+        let byte5 = UInt8((ump.word1 >> 16) & 0xFF)
+        let bankMsb = bankValid ? Uint7(byte4) : nil
+        let bankLsb = bankValid ? Uint7(byte5) : nil
+        self.init(group: group, channel: channel, program: program, bankMsb: bankMsb, bankLsb: bankLsb)
+    }
+}

--- a/Sources/MIDI2/Midi2ControlChange.swift
+++ b/Sources/MIDI2/Midi2ControlChange.swift
@@ -1,3 +1,0 @@
-/// Status 0xB (CC).
-public struct Midi2ControlChange {
-}

--- a/Sources/MIDI2/Midi2NoteOff.swift
+++ b/Sources/MIDI2/Midi2NoteOff.swift
@@ -1,3 +1,0 @@
-/// Status 0x8 (Note Off).
-public struct Midi2NoteOff {
-}

--- a/Sources/MIDI2/Midi2PitchBend.swift
+++ b/Sources/MIDI2/Midi2PitchBend.swift
@@ -1,3 +1,0 @@
-/// Status 0xE (Pitch Bend).
-public struct Midi2PitchBend {
-}

--- a/Sources/MIDI2/Midi2PolyPressure.swift
+++ b/Sources/MIDI2/Midi2PolyPressure.swift
@@ -1,3 +1,0 @@
-/// Status 0xA (Polyphonic Key Pressure).
-public struct Midi2PolyPressure {
-}

--- a/Sources/MIDI2/Midi2ProgramChange.swift
+++ b/Sources/MIDI2/Midi2ProgramChange.swift
@@ -1,3 +1,0 @@
-/// Status 0xC (Program Change).
-public struct Midi2ProgramChange {
-}

--- a/Sources/MIDI2/NoteAttributeType.swift
+++ b/Sources/MIDI2/NoteAttributeType.swift
@@ -1,2 +1,9 @@
-public struct NoteAttributeType {
+public struct NoteAttributeType: Equatable, Hashable, Sendable {
+    public let rawValue: UInt8
+
+    public init(_ rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static let none = NoteAttributeType(0)
 }

--- a/Sources/MIDI2/Uint4.swift
+++ b/Sources/MIDI2/Uint4.swift
@@ -1,2 +1,8 @@
-public struct Uint4 {
+public struct Uint4: Equatable, Hashable {
+    public let rawValue: UInt8
+
+    public init?(_ rawValue: UInt8) {
+        guard rawValue < 0x10 else { return nil }
+        self.rawValue = rawValue
+    }
 }

--- a/Sources/MIDI2/Uint7.swift
+++ b/Sources/MIDI2/Uint7.swift
@@ -1,2 +1,8 @@
-public struct Uint7 {
+public struct Uint7: Equatable, Hashable {
+    public let rawValue: UInt8
+
+    public init?(_ rawValue: UInt8) {
+        guard rawValue < 0x80 else { return nil }
+        self.rawValue = rawValue
+    }
 }

--- a/Tests/MIDI2Tests/ChannelVoice/ControlChangeTests.swift
+++ b/Tests/MIDI2Tests/ChannelVoice/ControlChangeTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MIDI2
+
+final class ControlChangeTests: XCTestCase {
+    func testRoundTrip() {
+        let message = ControlChange(
+            group: Uint4(0x0)!,
+            channel: Uint4(0x5)!,
+            control: Uint7(0x0A)!,
+            value: 0x87654321
+        )
+        let packet = message.ump()
+        XCTAssertEqual(packet.word0, 0x40B50A00)
+        XCTAssertEqual(packet.word1, 0x87654321)
+        let decoded = ControlChange(ump: packet)
+        XCTAssertEqual(decoded, message)
+    }
+}

--- a/Tests/MIDI2Tests/ChannelVoice/NoteOffTests.swift
+++ b/Tests/MIDI2Tests/ChannelVoice/NoteOffTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import MIDI2
+
+final class NoteOffTests: XCTestCase {
+    func testRoundTrip() {
+        let message = NoteOff(
+            group: Uint4(0x1)!,
+            channel: Uint4(0x2)!,
+            noteNumber: Uint7(0x3C)!,
+            velocity: 0x1234,
+            attributeType: NoteAttributeType(0x56),
+            attributeData: 0x789A
+        )
+        let packet = message.ump()
+        XCTAssertEqual(packet.word0, 0x41823C56)
+        XCTAssertEqual(packet.word1, 0x1234789A)
+        let decoded = NoteOff(ump: packet)
+        XCTAssertEqual(decoded, message)
+    }
+}

--- a/Tests/MIDI2Tests/ChannelVoice/PitchBendTests.swift
+++ b/Tests/MIDI2Tests/ChannelVoice/PitchBendTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import MIDI2
+
+final class PitchBendTests: XCTestCase {
+    func testRoundTrip() {
+        let message = PitchBend(
+            group: Uint4(0xF)!,
+            channel: Uint4(0x1)!,
+            value: 0x11223344
+        )
+        let packet = message.ump()
+        XCTAssertEqual(packet.word0, 0x4FE10000)
+        XCTAssertEqual(packet.word1, 0x11223344)
+        let decoded = PitchBend(ump: packet)
+        XCTAssertEqual(decoded, message)
+    }
+}

--- a/Tests/MIDI2Tests/ChannelVoice/PolyPressureTests.swift
+++ b/Tests/MIDI2Tests/ChannelVoice/PolyPressureTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MIDI2
+
+final class PolyPressureTests: XCTestCase {
+    func testRoundTrip() {
+        let message = PolyPressure(
+            group: Uint4(0x1)!,
+            channel: Uint4(0x0)!,
+            noteNumber: Uint7(0x40)!,
+            pressure: 0x12345678
+        )
+        let packet = message.ump()
+        XCTAssertEqual(packet.word0, 0x41A04000)
+        XCTAssertEqual(packet.word1, 0x12345678)
+        let decoded = PolyPressure(ump: packet)
+        XCTAssertEqual(decoded, message)
+    }
+}

--- a/Tests/MIDI2Tests/ChannelVoice/ProgramChangeTests.swift
+++ b/Tests/MIDI2Tests/ChannelVoice/ProgramChangeTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import MIDI2
+
+final class ProgramChangeTests: XCTestCase {
+    func testRoundTrip() {
+        let message = ProgramChange(
+            group: Uint4(0x2)!,
+            channel: Uint4(0x3)!,
+            program: Uint7(0x05)!,
+            bankMsb: Uint7(0x07)!,
+            bankLsb: Uint7(0x09)!
+        )
+        let packet = message.ump()
+        XCTAssertEqual(packet.word0, 0x42C30580)
+        XCTAssertEqual(packet.word1, 0x07090000)
+        let decoded = ProgramChange(ump: packet)
+        XCTAssertEqual(decoded, message)
+    }
+}

--- a/Tests/MIDI2Tests/Midi2ControlChangeTests.swift
+++ b/Tests/MIDI2Tests/Midi2ControlChangeTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import MIDI2
-
-final class Midi2ControlChangeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2ControlChange
-    }
-}

--- a/Tests/MIDI2Tests/Midi2NoteOffTests.swift
+++ b/Tests/MIDI2Tests/Midi2NoteOffTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import MIDI2
-
-final class Midi2NoteOffTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2NoteOff
-    }
-}

--- a/Tests/MIDI2Tests/Midi2PitchBendTests.swift
+++ b/Tests/MIDI2Tests/Midi2PitchBendTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import MIDI2
-
-final class Midi2PitchBendTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2PitchBend
-    }
-}

--- a/Tests/MIDI2Tests/Midi2PolyPressureTests.swift
+++ b/Tests/MIDI2Tests/Midi2PolyPressureTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import MIDI2
-
-final class Midi2PolyPressureTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2PolyPressure
-    }
-}

--- a/Tests/MIDI2Tests/Midi2ProgramChangeTests.swift
+++ b/Tests/MIDI2Tests/Midi2ProgramChangeTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import MIDI2
-
-final class Midi2ProgramChangeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2ProgramChange
-    }
-}


### PR DESCRIPTION
## Summary
- add typed UInt4/UInt7 wrappers and NoteAttributeType
- implement NoteOff, PolyPressure, ControlChange, ProgramChange, and PitchBend structs with 64-bit UMP encode/decode
- provide round-trip golden vector tests for channel voice messages

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689c1345732c8333bc923972b5067d5a