### PR TITLE
Add MIDI 1.0 channel voice UMP32 support

### DIFF
--- a/Sources/MIDI2/Midi1ChannelVoiceBody.swift
+++ b/Sources/MIDI2/Midi1ChannelVoiceBody.swift
@@ -1,3 +1,131 @@
-/// Messages share this body, with relevant fields set based on status.
-public struct Midi1ChannelVoiceBody {
+/// MIDI 1.0 Channel Voice messages translated to 32-bit UMP packets.
+public enum Midi1ChannelVoiceMessage: Equatable {
+    case noteOff(group: Uint4, channel: Uint4, note: Uint7, velocity: Uint7)
+    case noteOn(group: Uint4, channel: Uint4, note: Uint7, velocity: Uint7)
+    case polyPressure(group: Uint4, channel: Uint4, note: Uint7, pressure: Uint7)
+    case controlChange(group: Uint4, channel: Uint4, control: Uint7, value: Uint7)
+    case programChange(group: Uint4, channel: Uint4, program: Uint7)
+    case channelPressure(group: Uint4, channel: Uint4, pressure: Uint7)
+    case pitchBend(group: Uint4, channel: Uint4, value: Uint14)
+}
+
+public extension Midi1ChannelVoiceMessage {
+    func ump() -> UmpPacket32 {
+        switch self {
+        case let .noteOff(group, channel, note, velocity):
+            return pack(group: group, status: 0x8, channel: channel, data1: note.rawValue, data2: velocity.rawValue)
+        case let .noteOn(group, channel, note, velocity):
+            return pack(group: group, status: 0x9, channel: channel, data1: note.rawValue, data2: velocity.rawValue)
+        case let .polyPressure(group, channel, note, pressure):
+            return pack(group: group, status: 0xA, channel: channel, data1: note.rawValue, data2: pressure.rawValue)
+        case let .controlChange(group, channel, control, value):
+            return pack(group: group, status: 0xB, channel: channel, data1: control.rawValue, data2: value.rawValue)
+        case let .programChange(group, channel, program):
+            return pack(group: group, status: 0xC, channel: channel, data1: program.rawValue, data2: 0)
+        case let .channelPressure(group, channel, pressure):
+            return pack(group: group, status: 0xD, channel: channel, data1: pressure.rawValue, data2: 0)
+        case let .pitchBend(group, channel, value):
+            let lsb = UInt8(value.rawValue & 0x7F)
+            let msb = UInt8((value.rawValue >> 7) & 0x7F)
+            return pack(group: group, status: 0xE, channel: channel, data1: lsb, data2: msb)
+        }
+    }
+
+    private func pack(group: Uint4, status: UInt8, channel: Uint4, data1: UInt8, data2: UInt8) -> UmpPacket32 {
+        let statusByte = status << 4 | channel.rawValue
+        return UmpPacket32(mt: 0x2, group: group, status: statusByte, data1: data1, data2: data2)
+    }
+
+    init?(ump: UmpPacket32) {
+        let mt = UInt8((ump.word >> 28) & 0xF)
+        guard mt == 0x2 else { return nil }
+        guard let group = Uint4(UInt8((ump.word >> 24) & 0xF)) else { return nil }
+        let statusByte = UInt8((ump.word >> 16) & 0xFF)
+        let statusNibble = statusByte >> 4
+        guard let status = Midi1StatusNibble(statusNibble) else { return nil }
+        guard let channel = Uint4(statusByte & 0x0F) else { return nil }
+        let data1 = UInt8((ump.word >> 8) & 0xFF)
+        let data2 = UInt8(ump.word & 0xFF)
+
+        switch status {
+        case .noteOff:
+            guard let note = Uint7(data1), let velocity = Uint7(data2) else { return nil }
+            self = .noteOff(group: group, channel: channel, note: note, velocity: velocity)
+        case .noteOn:
+            guard let note = Uint7(data1), let velocity = Uint7(data2) else { return nil }
+            self = .noteOn(group: group, channel: channel, note: note, velocity: velocity)
+        case .polyPressure:
+            guard let note = Uint7(data1), let pressure = Uint7(data2) else { return nil }
+            self = .polyPressure(group: group, channel: channel, note: note, pressure: pressure)
+        case .controlChange:
+            guard let control = Uint7(data1), let value = Uint7(data2) else { return nil }
+            self = .controlChange(group: group, channel: channel, control: control, value: value)
+        case .programChange:
+            guard let program = Uint7(data1) else { return nil }
+            self = .programChange(group: group, channel: channel, program: program)
+        case .channelPressure:
+            guard let pressure = Uint7(data1) else { return nil }
+            self = .channelPressure(group: group, channel: channel, pressure: pressure)
+        case .pitchBend:
+            let value14 = UInt16(data2) << 7 | UInt16(data1)
+            guard let bend = Uint14(value14) else { return nil }
+            self = .pitchBend(group: group, channel: channel, value: bend)
+        }
+    }
+
+    func midi1Bytes() -> [UInt8] {
+        switch self {
+        case let .noteOff(_, channel, note, velocity):
+            return [0x80 | channel.rawValue, note.rawValue, velocity.rawValue]
+        case let .noteOn(_, channel, note, velocity):
+            return [0x90 | channel.rawValue, note.rawValue, velocity.rawValue]
+        case let .polyPressure(_, channel, note, pressure):
+            return [0xA0 | channel.rawValue, note.rawValue, pressure.rawValue]
+        case let .controlChange(_, channel, control, value):
+            return [0xB0 | channel.rawValue, control.rawValue, value.rawValue]
+        case let .programChange(_, channel, program):
+            return [0xC0 | channel.rawValue, program.rawValue]
+        case let .channelPressure(_, channel, pressure):
+            return [0xD0 | channel.rawValue, pressure.rawValue]
+        case let .pitchBend(_, channel, value):
+            let lsb = UInt8(value.rawValue & 0x7F)
+            let msb = UInt8((value.rawValue >> 7) & 0x7F)
+            return [0xE0 | channel.rawValue, lsb, msb]
+        }
+    }
+
+    init?(midi1Bytes bytes: [UInt8], group: Uint4) {
+        guard bytes.count >= 2 else { return nil }
+        let statusByte = bytes[0]
+        let statusNibble = statusByte >> 4
+        guard let status = Midi1StatusNibble(statusNibble) else { return nil }
+        guard let channel = Uint4(statusByte & 0x0F) else { return nil }
+        let data1 = bytes[1]
+        let data2: UInt8 = bytes.count > 2 ? bytes[2] : 0
+
+        switch status {
+        case .noteOff:
+            guard let note = Uint7(data1), let velocity = Uint7(data2) else { return nil }
+            self = .noteOff(group: group, channel: channel, note: note, velocity: velocity)
+        case .noteOn:
+            guard let note = Uint7(data1), let velocity = Uint7(data2) else { return nil }
+            self = .noteOn(group: group, channel: channel, note: note, velocity: velocity)
+        case .polyPressure:
+            guard let note = Uint7(data1), let pressure = Uint7(data2) else { return nil }
+            self = .polyPressure(group: group, channel: channel, note: note, pressure: pressure)
+        case .controlChange:
+            guard let control = Uint7(data1), let value = Uint7(data2) else { return nil }
+            self = .controlChange(group: group, channel: channel, control: control, value: value)
+        case .programChange:
+            guard let program = Uint7(data1) else { return nil }
+            self = .programChange(group: group, channel: channel, program: program)
+        case .channelPressure:
+            guard let pressure = Uint7(data1) else { return nil }
+            self = .channelPressure(group: group, channel: channel, pressure: pressure)
+        case .pitchBend:
+            let value14 = UInt16(data2) << 7 | UInt16(data1)
+            guard let bend = Uint14(value14) else { return nil }
+            self = .pitchBend(group: group, channel: channel, value: bend)
+        }
+    }
 }

--- a/Sources/MIDI2/Midi1StatusNibble.swift
+++ b/Sources/MIDI2/Midi1StatusNibble.swift
@@ -1,3 +1,14 @@
 /// 0x8..0xE
-public struct Midi1StatusNibble {
+public enum Midi1StatusNibble: UInt8 {
+    case noteOff        = 0x8
+    case noteOn         = 0x9
+    case polyPressure   = 0xA
+    case controlChange  = 0xB
+    case programChange  = 0xC
+    case channelPressure = 0xD
+    case pitchBend      = 0xE
+
+    public init?(_ raw: UInt8) {
+        self.init(rawValue: raw)
+    }
 }

--- a/Sources/MIDI2/Uint14.swift
+++ b/Sources/MIDI2/Uint14.swift
@@ -1,2 +1,8 @@
-public struct Uint14 {
+public struct Uint14: Equatable, Hashable {
+    public let rawValue: UInt16
+
+    public init?(_ rawValue: UInt16) {
+        guard rawValue < 0x4000 else { return nil }
+        self.rawValue = rawValue
+    }
 }

--- a/Sources/MIDI2/UmpPacket32.swift
+++ b/Sources/MIDI2/UmpPacket32.swift
@@ -1,2 +1,35 @@
-public struct UmpPacket32 {
+public struct UmpPacket32: Equatable {
+    public let word: UInt32
+
+    public init(word: UInt32) {
+        self.word = word
+    }
+
+    public init(mt: UInt8, group: Uint4, status: UInt8, data1: UInt8, data2: UInt8) {
+        let byte0 = UInt32(mt << 4 | group.rawValue)
+        let word = (byte0 << 24) | (UInt32(status) << 16) | (UInt32(data1) << 8) | UInt32(data2)
+        self.word = word
+    }
+
+    public init?(midi1Bytes bytes: [UInt8], group: Uint4) {
+        guard bytes.count >= 2 else { return nil }
+        let status = bytes[0]
+        let data1 = bytes[1]
+        let data2: UInt8 = bytes.count > 2 ? bytes[2] : 0
+        self.init(mt: 0x2, group: group, status: status, data1: data1, data2: data2)
+    }
+
+    public func midi1Bytes() -> [UInt8]? {
+        let mt = UInt8((word >> 28) & 0xF)
+        guard mt == 0x2 else { return nil }
+        let status = UInt8((word >> 16) & 0xFF)
+        let data1 = UInt8((word >> 8) & 0xFF)
+        let data2 = UInt8(word & 0xFF)
+        let statusNibble = status >> 4
+        if statusNibble == 0xC || statusNibble == 0xD {
+            return [status, data1]
+        } else {
+            return [status, data1, data2]
+        }
+    }
 }

--- a/Tests/MIDI2Tests/MIDI1CompatTests.swift
+++ b/Tests/MIDI2Tests/MIDI1CompatTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import MIDI2
+
+final class MIDI1CompatTests: XCTestCase {
+    func testCanonicalSequences() {
+        let g = Uint4(0)!
+        let messages: [(Midi1ChannelVoiceMessage, UInt32)] = [
+            (.noteOn(group: g, channel: Uint4(0)!, note: Uint7(0x3C)!, velocity: Uint7(0x40)!), 0x20903C40),
+            (.noteOff(group: g, channel: Uint4(1)!, note: Uint7(0x3C)!, velocity: Uint7(0x00)!), 0x20813C00),
+            (.polyPressure(group: g, channel: Uint4(2)!, note: Uint7(0x10)!, pressure: Uint7(0x20)!), 0x20A21020),
+            (.controlChange(group: g, channel: Uint4(3)!, control: Uint7(0x07)!, value: Uint7(0x40)!), 0x20B30740),
+            (.programChange(group: g, channel: Uint4(4)!, program: Uint7(0x22)!), 0x20C42200),
+            (.channelPressure(group: g, channel: Uint4(5)!, pressure: Uint7(0x40)!), 0x20D54000),
+            (.pitchBend(group: g, channel: Uint4(6)!, value: Uint14(0x2000)!), 0x20E60040)
+        ]
+        for (msg, word) in messages {
+            let packet = msg.ump()
+            XCTAssertEqual(packet.word, word)
+            let decoded = Midi1ChannelVoiceMessage(ump: packet)
+            XCTAssertEqual(decoded, msg)
+            XCTAssertEqual(decoded?.midi1Bytes(), msg.midi1Bytes())
+        }
+    }
+
+    func testRoundTripBytes() {
+        let g = Uint4(0)!
+        let sequences: [[UInt8]] = [
+            [0x90, 0x3C, 0x40],
+            [0x80, 0x3C, 0x00],
+            [0xA2, 0x10, 0x20],
+            [0xB3, 0x07, 0x40],
+            [0xC4, 0x22],
+            [0xD5, 0x40],
+            [0xE6, 0x00, 0x40]
+        ]
+        for bytes in sequences {
+            let msg = Midi1ChannelVoiceMessage(midi1Bytes: bytes, group: g)
+            XCTAssertNotNil(msg)
+            let packet = msg!.ump()
+            let rt = Midi1ChannelVoiceMessage(ump: packet)
+            XCTAssertEqual(rt?.midi1Bytes(), bytes)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement UMP32 packet structure with MIDI 1.0 byte translation helpers
- add MIDI 1.0 status nibble enum and channel voice message conversions
- cover canonical MIDI 1.0 sequences with round-trip tests

## Testing
- `swift test --enable-test-discovery`


------
https://chatgpt.com/codex/tasks/task_b_689c153ed4888333894e4ca3c0d7fe9b