### PR TITLE
Add per-note controller types and address enums

### DIFF
--- a/Sources/MIDI2/Midi2AssignPerNoteController.swift
+++ b/Sources/MIDI2/Midi2AssignPerNoteController.swift
@@ -1,2 +1,22 @@
-public struct Midi2AssignPerNoteController {
+/// Assignable Per-Note Controller address.
+///
+/// These addresses correspond to per-note controller numbers that can be
+/// freely assigned. Valid values are in the 7-bit range `0...127`.
+public enum Midi2AssignableControllerAddress: Equatable {
+    /// Raw controller number.
+    case number(Swift.UInt8)
+
+    /// Creates an address from a raw 7-bit value. Returns `nil` if the value
+    /// exceeds the permitted range.
+    public init?(rawValue: Swift.UInt8) {
+        guard rawValue <= 0x7F else { return nil }
+        self = .number(rawValue)
+    }
+
+    /// The raw controller number.
+    public var rawValue: Swift.UInt8 {
+        switch self {
+            case .number(let v): return v
+        }
+    }
 }

--- a/Sources/MIDI2/Midi2NRPN.swift
+++ b/Sources/MIDI2/Midi2NRPN.swift
@@ -1,3 +1,22 @@
-/// Assignable Controller (absolute).
-public struct Midi2NRPN {
+/// Non-Registered Parameter Number (NRPN) address.
+///
+/// NRPN addresses are 14-bit values representing assignable controller
+/// numbers. All values in the range `0...0x3FFF` are valid.
+public enum Midi2NRPNAddress: Equatable {
+    /// The raw NRPN value.
+    case number(Swift.UInt16)
+
+    /// Creates an NRPN address from the raw 14-bit value. Returns `nil` if the
+    /// value is outside the permitted range `0...0x3FFF`.
+    public init?(rawValue: Swift.UInt16) {
+        guard rawValue <= 0x3FFF else { return nil }
+        self = .number(rawValue)
+    }
+
+    /// The raw 14-bit address value.
+    public var rawValue: Swift.UInt16 {
+        switch self {
+            case .number(let v): return v
+        }
+    }
 }

--- a/Sources/MIDI2/Midi2RPN.swift
+++ b/Sources/MIDI2/Midi2RPN.swift
@@ -1,3 +1,37 @@
-/// Registered Controller (absolute).
-public struct Midi2RPN {
+/// Registered Parameter Number (RPN) address.
+///
+/// RPN addresses are 14-bit values. This enum models well-known
+/// addresses and allows representing any other address within the
+/// valid range.
+public enum Midi2RPNAddress: Equatable {
+    /// Per-Note Pitch controller (RPN 0).
+    case perNotePitch
+    /// Per-Note Pressure controller (RPN 1).
+    case perNotePressure
+    /// Per-Note Timbre controller (RPN 2).
+    case perNoteTimbre
+    /// Any other RPN address within the 14-bit range.
+    case other(Swift.UInt16)
+
+    /// Creates an RPN address from the raw 14-bit value. Returns `nil` if the
+    /// value is outside the permitted range `0...0x3FFF`.
+    public init?(rawValue: Swift.UInt16) {
+        guard rawValue <= 0x3FFF else { return nil }
+        switch rawValue {
+            case 0x0000: self = .perNotePitch
+            case 0x0001: self = .perNotePressure
+            case 0x0002: self = .perNoteTimbre
+            default: self = .other(rawValue)
+        }
+    }
+
+    /// The raw 14-bit address value.
+    public var rawValue: Swift.UInt16 {
+        switch self {
+            case .perNotePitch: return 0x0000
+            case .perNotePressure: return 0x0001
+            case .perNoteTimbre: return 0x0002
+            case .other(let v): return v
+        }
+    }
 }

--- a/Sources/MIDI2/PerNote/Pitch.swift
+++ b/Sources/MIDI2/PerNote/Pitch.swift
@@ -1,0 +1,29 @@
+/// Per-Note Pitch value.
+///
+/// Stored as a signed 32-bit integer. The full `Int32` range is
+/// available which allows representing pitch offsets using the
+/// 16.16 fixed-point format defined by the MIDI 2.0 specification.
+public struct PerNotePitch: Equatable {
+    /// Raw pitch value.
+    public let value: Swift.Int32
+
+    /// Creates a pitch value. Returns `nil` if the value is outside the
+    /// valid 32-bit signed integer range.
+    public init?(_ value: Swift.Int64) {
+        guard value >= Swift.Int64(Swift.Int32.min) && value <= Swift.Int64(Swift.Int32.max) else {
+            return nil
+        }
+        self.value = Swift.Int32(value)
+    }
+
+    /// Encodes the pitch to its 32-bit representation.
+    public func encode() -> Swift.UInt32 {
+        Swift.UInt32(bitPattern: value)
+    }
+
+    /// Decodes a 32-bit representation into a `PerNotePitch`.
+    public static func decode(_ rawValue: Swift.UInt32) -> PerNotePitch {
+        // Decoding always succeeds because all 32-bit patterns are valid.
+        PerNotePitch(Swift.Int64(Swift.Int32(bitPattern: rawValue)))!
+    }
+}

--- a/Sources/MIDI2/PerNote/Pressure.swift
+++ b/Sources/MIDI2/PerNote/Pressure.swift
@@ -1,0 +1,23 @@
+/// Per-Note Pressure value.
+///
+/// Stored as an unsigned 32-bit integer spanning the full range
+/// `0...UInt32.max`.
+public struct PerNotePressure: Equatable {
+    /// Raw pressure value.
+    public let value: Swift.UInt32
+
+    /// Creates a pressure value. Returns `nil` if the supplied value is
+    /// outside the valid unsigned 32-bit range.
+    public init?(_ value: Swift.UInt64) {
+        guard value <= Swift.UInt64(Swift.UInt32.max) else { return nil }
+        self.value = Swift.UInt32(value)
+    }
+
+    /// Encodes the pressure to its raw 32-bit representation.
+    public func encode() -> Swift.UInt32 { value }
+
+    /// Decodes a 32-bit representation into a `PerNotePressure`.
+    public static func decode(_ rawValue: Swift.UInt32) -> PerNotePressure {
+        PerNotePressure(Swift.UInt64(rawValue))!
+    }
+}

--- a/Sources/MIDI2/PerNote/Timbre.swift
+++ b/Sources/MIDI2/PerNote/Timbre.swift
@@ -1,0 +1,23 @@
+/// Per-Note Timbre value.
+///
+/// Stored as an unsigned 32-bit integer spanning the full range
+/// `0...UInt32.max`.
+public struct PerNoteTimbre: Equatable {
+    /// Raw timbre value.
+    public let value: Swift.UInt32
+
+    /// Creates a timbre value. Returns `nil` if the supplied value is
+    /// outside the valid unsigned 32-bit range.
+    public init?(_ value: Swift.UInt64) {
+        guard value <= Swift.UInt64(Swift.UInt32.max) else { return nil }
+        self.value = Swift.UInt32(value)
+    }
+
+    /// Encodes the timbre to its raw 32-bit representation.
+    public func encode() -> Swift.UInt32 { value }
+
+    /// Decodes a 32-bit representation into a `PerNoteTimbre`.
+    public static func decode(_ rawValue: Swift.UInt32) -> PerNoteTimbre {
+        PerNoteTimbre(Swift.UInt64(rawValue))!
+    }
+}

--- a/Tests/MIDI2Tests/AssignableControllerAddressTests.swift
+++ b/Tests/MIDI2Tests/AssignableControllerAddressTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import MIDI2
+
+final class AssignableControllerAddressTests: XCTestCase {
+    func testRoundTrip() {
+        let addr = Midi2AssignableControllerAddress(rawValue: 0x40)
+        XCTAssertEqual(addr?.rawValue, 0x40)
+    }
+
+    func testBounds() {
+        XCTAssertNotNil(Midi2AssignableControllerAddress(rawValue: 0))
+        XCTAssertNotNil(Midi2AssignableControllerAddress(rawValue: 0x7F))
+        XCTAssertNil(Midi2AssignableControllerAddress(rawValue: 0x80))
+    }
+}

--- a/Tests/MIDI2Tests/NrpnAddressTests.swift
+++ b/Tests/MIDI2Tests/NrpnAddressTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import MIDI2
+
+final class NrpnAddressTests: XCTestCase {
+    func testRoundTrip() {
+        let addr = Midi2NRPNAddress(rawValue: 0x1ABC)
+        XCTAssertEqual(addr?.rawValue, 0x1ABC)
+    }
+
+    func testBounds() {
+        XCTAssertNotNil(Midi2NRPNAddress(rawValue: 0))
+        XCTAssertNotNil(Midi2NRPNAddress(rawValue: 0x3FFF))
+        XCTAssertNil(Midi2NRPNAddress(rawValue: 0x4000))
+    }
+}

--- a/Tests/MIDI2Tests/PerNote/PitchTests.swift
+++ b/Tests/MIDI2Tests/PerNote/PitchTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MIDI2
+
+final class PerNotePitchTests: XCTestCase {
+    func testEncodingDecoding() {
+        guard let pitch = PerNotePitch(12345) else { return XCTFail("init failed") }
+        let encoded = pitch.encode()
+        let decoded = PerNotePitch.decode(encoded)
+        XCTAssertEqual(decoded, pitch)
+    }
+
+    func testBounds() {
+        XCTAssertNotNil(PerNotePitch(Swift.Int64(Swift.Int32.min)))
+        XCTAssertNotNil(PerNotePitch(Swift.Int64(Swift.Int32.max)))
+        XCTAssertNil(PerNotePitch(Swift.Int64(Swift.Int32.min) - 1))
+        XCTAssertNil(PerNotePitch(Swift.Int64(Swift.Int32.max) + 1))
+    }
+}

--- a/Tests/MIDI2Tests/PerNote/PressureTests.swift
+++ b/Tests/MIDI2Tests/PerNote/PressureTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import MIDI2
+
+final class PerNotePressureTests: XCTestCase {
+    func testEncodingDecoding() {
+        guard let pressure = PerNotePressure(0xDEADBEEF) else { return XCTFail("init failed") }
+        let encoded = pressure.encode()
+        let decoded = PerNotePressure.decode(encoded)
+        XCTAssertEqual(decoded, pressure)
+    }
+
+    func testBounds() {
+        XCTAssertNotNil(PerNotePressure(0))
+        XCTAssertNotNil(PerNotePressure(Swift.UInt64(Swift.UInt32.max)))
+        XCTAssertNil(PerNotePressure(Swift.UInt64(Swift.UInt32.max) + 1))
+    }
+}

--- a/Tests/MIDI2Tests/PerNote/TimbreTests.swift
+++ b/Tests/MIDI2Tests/PerNote/TimbreTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import MIDI2
+
+final class PerNoteTimbreTests: XCTestCase {
+    func testEncodingDecoding() {
+        guard let timbre = PerNoteTimbre(0x12345678) else { return XCTFail("init failed") }
+        let encoded = timbre.encode()
+        let decoded = PerNoteTimbre.decode(encoded)
+        XCTAssertEqual(decoded, timbre)
+    }
+
+    func testBounds() {
+        XCTAssertNotNil(PerNoteTimbre(0))
+        XCTAssertNotNil(PerNoteTimbre(Swift.UInt64(Swift.UInt32.max)))
+        XCTAssertNil(PerNoteTimbre(Swift.UInt64(Swift.UInt32.max) + 1))
+    }
+}

--- a/Tests/MIDI2Tests/RpnAddressTests.swift
+++ b/Tests/MIDI2Tests/RpnAddressTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MIDI2
+
+final class RpnAddressTests: XCTestCase {
+    func testKnownAddresses() {
+        XCTAssertEqual(Midi2RPNAddress(rawValue: 0x0000), .perNotePitch)
+        XCTAssertEqual(Midi2RPNAddress(rawValue: 0x0001), .perNotePressure)
+        XCTAssertEqual(Midi2RPNAddress(rawValue: 0x0002), .perNoteTimbre)
+    }
+
+    func testOtherAndBounds() {
+        let other = Midi2RPNAddress(rawValue: 0x1234)
+        XCTAssertEqual(other?.rawValue, 0x1234)
+        let max = Midi2RPNAddress(rawValue: 0x3FFF)
+        XCTAssertEqual(max?.rawValue, 0x3FFF)
+        XCTAssertNil(Midi2RPNAddress(rawValue: 0x4000))
+    }
+}


### PR DESCRIPTION
## Summary
- add per-note pitch, pressure, and timbre value types with encoding, decoding, and range checks
- introduce enums modeling RPN, NRPN, and assignable controller addresses with validation
- cover per-note controllers and address enums with exhaustive boundary tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689c172ce6cc8333a4a784ffe04088d0