### PR TITLE
Add system and utility UMP packet support

### DIFF
--- a/Sources/MIDI2/System/SystemCommon.swift
+++ b/Sources/MIDI2/System/SystemCommon.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// UMP Type 0x1 System Common messages.
+public enum SystemCommon: Equatable {
+    case mtcQuarterFrame(group: Uint4, message: Uint7)
+    case songPositionPointer(group: Uint4, position: Uint14)
+    case songSelect(group: Uint4, song: Uint7)
+    case tuneRequest(group: Uint4)
+
+    public var group: Uint4 {
+        switch self {
+        case .mtcQuarterFrame(let g, _), .songPositionPointer(let g, _), .songSelect(let g, _), .tuneRequest(let g):
+            return g
+        }
+    }
+
+    private var status: UInt8 {
+        switch self {
+        case .mtcQuarterFrame: return 0xF1
+        case .songPositionPointer: return 0xF2
+        case .songSelect: return 0xF3
+        case .tuneRequest: return 0xF6
+        }
+    }
+
+    /// Encodes the message into a 32-bit UMP packet.
+    public func ump() -> UmpPacket32 {
+        let byte0 = UInt32(0x1 << 4 | group.rawValue)
+        let status = UInt32(self.status)
+        let data1: UInt32
+        let data2: UInt32
+        switch self {
+        case .mtcQuarterFrame(_, let message):
+            data1 = UInt32(message.rawValue)
+            data2 = 0
+        case .songPositionPointer(_, let position):
+            data1 = UInt32(position.rawValue & 0x7F)
+            data2 = UInt32((position.rawValue >> 7) & 0x7F)
+        case .songSelect(_, let song):
+            data1 = UInt32(song.rawValue)
+            data2 = 0
+        case .tuneRequest:
+            data1 = 0
+            data2 = 0
+        }
+        let word = (byte0 << 24) | (status << 16) | (data1 << 8) | data2
+        return UmpPacket32(word: word)
+    }
+
+    /// Decodes a 32-bit UMP packet.
+    public init?(ump: UmpPacket32) {
+        let mt = UInt8((ump.word >> 28) & 0xF)
+        guard mt == 0x1 else { return nil }
+        let byte0 = UInt8((ump.word >> 24) & 0xFF)
+        guard let group = Uint4(byte0 & 0x0F) else { return nil }
+        let status = UInt8((ump.word >> 16) & 0xFF)
+        guard status >> 4 == 0xF else { return nil }
+        let data1 = UInt8((ump.word >> 8) & 0xFF)
+        let data2 = UInt8(ump.word & 0xFF)
+        switch status {
+        case 0xF1:
+            guard let msg = Uint7(data1) else { return nil }
+            self = .mtcQuarterFrame(group: group, message: msg)
+        case 0xF2:
+            let value = UInt16(data1 & 0x7F) | (UInt16(data2 & 0x7F) << 7)
+            guard let pos = Uint14(value) else { return nil }
+            self = .songPositionPointer(group: group, position: pos)
+        case 0xF3:
+            guard let song = Uint7(data1) else { return nil }
+            self = .songSelect(group: group, song: song)
+        case 0xF6:
+            self = .tuneRequest(group: group)
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/MIDI2/System/SystemRealTime.swift
+++ b/Sources/MIDI2/System/SystemRealTime.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// UMP Type 0x1 System Real-Time messages.
+public enum SystemRealTime: Equatable {
+    case timingClock(group: Uint4)
+    case start(group: Uint4)
+    case `continue`(group: Uint4)
+    case stop(group: Uint4)
+    case activeSensing(group: Uint4)
+    case systemReset(group: Uint4)
+
+    public var group: Uint4 {
+        switch self {
+        case .timingClock(let g), .start(let g), .continue(let g), .stop(let g), .activeSensing(let g), .systemReset(let g):
+            return g
+        }
+    }
+
+    private var status: UInt8 {
+        switch self {
+        case .timingClock: return 0xF8
+        case .start: return 0xFA
+        case .continue: return 0xFB
+        case .stop: return 0xFC
+        case .activeSensing: return 0xFE
+        case .systemReset: return 0xFF
+        }
+    }
+
+    /// Encodes the message into a 32-bit UMP packet.
+    public func ump() -> UmpPacket32 {
+        let byte0 = UInt32(0x1 << 4 | group.rawValue)
+        let word = (byte0 << 24) | (UInt32(status) << 16)
+        return UmpPacket32(word: word)
+    }
+
+    /// Decodes a 32-bit UMP packet.
+    public init?(ump: UmpPacket32) {
+        let mt = UInt8((ump.word >> 28) & 0xF)
+        guard mt == 0x1 else { return nil }
+        let byte0 = UInt8((ump.word >> 24) & 0xFF)
+        guard let group = Uint4(byte0 & 0x0F) else { return nil }
+        let status = UInt8((ump.word >> 16) & 0xFF)
+        guard status >> 4 == 0xF else { return nil }
+        switch status {
+        case 0xF8: self = .timingClock(group: group)
+        case 0xFA: self = .start(group: group)
+        case 0xFB: self = .continue(group: group)
+        case 0xFC: self = .stop(group: group)
+        case 0xFE: self = .activeSensing(group: group)
+        case 0xFF: self = .systemReset(group: group)
+        default: return nil
+        }
+    }
+}

--- a/Sources/MIDI2/System/Utility.swift
+++ b/Sources/MIDI2/System/Utility.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// UMP Type 0x0 Utility messages (groupless).
+public enum Utility: Equatable {
+    /// No operation. Used for padding.
+    case noop
+    /// Jitter reduction clock. 16-bit timestamp.
+    case jrClock(UInt16)
+    /// Jitter reduction timestamp. 16-bit timestamp.
+    case jrTimestamp(UInt16)
+
+    /// Encodes the message into a 32-bit UMP packet.
+    public func ump() -> UmpPacket32 {
+        let status: UInt8
+        let data: UInt16
+        switch self {
+        case .noop:
+            status = 0x00
+            data = 0
+        case .jrClock(let value):
+            status = 0x01
+            data = value
+        case .jrTimestamp(let value):
+            status = 0x02
+            data = value
+        }
+        let byte0 = UInt32(0x0 << 4) // message type 0x0, groupless
+        let word = (byte0 << 24) | (UInt32(status) << 16) | UInt32(data)
+        return UmpPacket32(word: word)
+    }
+
+    /// Decodes a 32-bit UMP packet.
+    public init?(ump: UmpPacket32) {
+        let mt = UInt8((ump.word >> 28) & 0xF)
+        guard mt == 0x0 else { return nil }
+        let byte0 = UInt8((ump.word >> 24) & 0xFF)
+        guard (byte0 & 0x0F) == 0 else { return nil } // groupless
+        let status = UInt8((ump.word >> 16) & 0xFF)
+        let data = UInt16(ump.word & 0xFFFF)
+        switch status {
+        case 0x00:
+            self = .noop
+        case 0x01:
+            self = .jrClock(data)
+        case 0x02:
+            self = .jrTimestamp(data)
+        default:
+            return nil
+        }
+    }
+}

--- a/Tests/MIDI2Tests/System/SystemCommonTests.swift
+++ b/Tests/MIDI2Tests/System/SystemCommonTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import MIDI2
+
+final class SystemCommonTests: XCTestCase {
+    func testRoundTripSongPosition() {
+        let msg = SystemCommon.songPositionPointer(group: Uint4(0x3)!, position: Uint14(0x1FFF)!)
+        let ump = msg.ump()
+        let decoded = SystemCommon(ump: ump)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testRoundTripTuneRequest() {
+        let msg = SystemCommon.tuneRequest(group: Uint4(0x4)!)
+        let ump = msg.ump()
+        let decoded = SystemCommon(ump: ump)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testMalformedStatus() {
+        // status 0xF4 is undefined for System Common
+        let byte0 = UInt32(0x1 << 4 | 0x1)
+        let status = UInt32(0xF4)
+        let word = (byte0 << 24) | (status << 16)
+        let ump = UmpPacket32(word: word)
+        XCTAssertNil(SystemCommon(ump: ump))
+    }
+}

--- a/Tests/MIDI2Tests/System/SystemRealTimeTests.swift
+++ b/Tests/MIDI2Tests/System/SystemRealTimeTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import MIDI2
+
+final class SystemRealTimeTests: XCTestCase {
+    func testRoundTripClock() {
+        let msg = SystemRealTime.timingClock(group: Uint4(0x2)!)
+        let ump = msg.ump()
+        let decoded = SystemRealTime(ump: ump)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testMalformedStatus() {
+        // status 0xF1 is System Common, not Real-Time
+        let byte0 = UInt32(0x1 << 4 | 0x0)
+        let word = (byte0 << 24) | (UInt32(0xF1) << 16)
+        let ump = UmpPacket32(word: word)
+        XCTAssertNil(SystemRealTime(ump: ump))
+    }
+}

--- a/Tests/MIDI2Tests/System/UtilityTests.swift
+++ b/Tests/MIDI2Tests/System/UtilityTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import MIDI2
+
+final class UtilityTests: XCTestCase {
+    func testRoundTripJRClock() {
+        let msg = Utility.jrClock(0x1234)
+        let ump = msg.ump()
+        let decoded = Utility(ump: ump)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testMalformedGroupNibble() {
+        // group nibble must be zero for utility messages
+        let byte0 = UInt32(0x0 << 4 | 0x1) // mt=0, group=1 -> invalid
+        let word = (byte0 << 24) | (UInt32(0x00) << 16)
+        let ump = UmpPacket32(word: word)
+        XCTAssertNil(Utility(ump: ump))
+    }
+}


### PR DESCRIPTION
## Summary
- Implement groupless Utility packets with NOOP, JR Clock, and JR Timestamp handling
- Support System Real-Time events and System Common messages including Song Position and Tune Request
- Add round-trip and malformed packet tests for system and utility messages

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689c18bca8a883338b2a038b4be9b3ec