### PR TITLE
Add SysEx7 and SysEx8 streaming helpers with tests

### DIFF
--- a/Sources/MIDI2/Data/SysEx7.swift
+++ b/Sources/MIDI2/Data/SysEx7.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Helpers for streaming SysEx7 data in UMP packets.
+public enum SysEx7 {
+    public enum StreamError: Error {
+        case invalidManufacturerID
+        case payloadTooLong
+        case invalidPacketSequence
+        case wrongMessageType
+    }
+
+    private static let maxChunk = 6
+    private static let maxPayloadLength = 0xFFFF
+
+    /// Fragment a SysEx7 payload into UMP packets.
+    /// - Parameters:
+    ///   - manufacturerID: 1 or 3 byte manufacturer identifier.
+    ///   - payload: SysEx payload bytes excluding manufacturer ID.
+    ///   - group: UMP group (0-15).
+    /// - Returns: Array of 8 byte UMP packets.
+    public static func fragment(manufacturerID: [UInt8], payload: [UInt8], group: UInt8 = 0) throws -> [[UInt8]] {
+        guard isValidManufacturerID(manufacturerID) else { throw StreamError.invalidManufacturerID }
+        guard payload.count <= maxPayloadLength else { throw StreamError.payloadTooLong }
+
+        let message = manufacturerID + payload
+        var packets: [[UInt8]] = []
+        var index = 0
+        let totalChunks = Int(ceil(Double(message.count) / Double(maxChunk)))
+
+        while index < message.count {
+            let remaining = message.count - index
+            let chunkSize = min(maxChunk, remaining)
+            let chunk = Array(message[index..<index+chunkSize])
+            let status: UInt8
+            if totalChunks == 1 {
+                status = 0x0 // complete in one packet
+            } else if index == 0 {
+                status = 0x1 // start
+            } else if remaining <= maxChunk {
+                status = 0x3 // end
+            } else {
+                status = 0x2 // continue
+            }
+            var packet: [UInt8] = [0x30 | (group & 0x0F), (status << 4) | UInt8(chunk.count)]
+            packet.append(contentsOf: chunk)
+            if chunk.count < maxChunk {
+                packet.append(contentsOf: Array(repeating: 0, count: maxChunk - chunk.count))
+            }
+            packets.append(packet)
+            index += chunkSize
+        }
+        return packets
+    }
+
+    /// Reassemble SysEx7 payload from UMP packets.
+    /// - Parameter packets: Array of 8 byte UMP packets.
+    /// - Returns: Manufacturer ID and payload.
+    public static func reassemble(_ packets: [[UInt8]]) throws -> (manufacturerID: [UInt8], payload: [UInt8]) {
+        guard !packets.isEmpty else { throw StreamError.invalidPacketSequence }
+        var bytes: [UInt8] = []
+        for (i, packet) in packets.enumerated() {
+            guard packet.count == 8 else { throw StreamError.invalidPacketSequence }
+            let mt = packet[0] >> 4
+            guard mt == 0x3 else { throw StreamError.wrongMessageType }
+            let status = packet[1] >> 4
+            let count = Int(packet[1] & 0x0F)
+            guard count <= maxChunk else { throw StreamError.invalidPacketSequence }
+            let data = Array(packet[2..<(2 + maxChunk)]).prefix(count)
+            bytes.append(contentsOf: data)
+
+            switch status {
+            case 0x0:
+                if packets.count != 1 { throw StreamError.invalidPacketSequence }
+            case 0x1:
+                if i != 0 { throw StreamError.invalidPacketSequence }
+            case 0x2:
+                if i == 0 || i == packets.count - 1 { throw StreamError.invalidPacketSequence }
+            case 0x3:
+                if i != packets.count - 1 { throw StreamError.invalidPacketSequence }
+            default:
+                throw StreamError.invalidPacketSequence
+            }
+        }
+        guard !bytes.isEmpty else { throw StreamError.invalidPacketSequence }
+        let manufacturerID: [UInt8]
+        let payload: [UInt8]
+        if bytes[0] == 0x00 {
+            guard bytes.count >= 3 else { throw StreamError.invalidManufacturerID }
+            manufacturerID = Array(bytes[0..<3])
+            payload = Array(bytes.dropFirst(3))
+        } else {
+            manufacturerID = [bytes[0]]
+            payload = Array(bytes.dropFirst())
+        }
+        guard isValidManufacturerID(manufacturerID) else { throw StreamError.invalidManufacturerID }
+        return (manufacturerID, payload)
+    }
+
+    private static func isValidManufacturerID(_ id: [UInt8]) -> Bool {
+        if id.count == 1 {
+            return id[0] != 0x00
+        } else if id.count == 3 {
+            return id[0] == 0x00
+        } else {
+            return false
+        }
+    }
+}
+

--- a/Sources/MIDI2/Data/SysEx8.swift
+++ b/Sources/MIDI2/Data/SysEx8.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Helpers for streaming SysEx8 data in UMP packets.
+public enum SysEx8 {
+    public enum StreamError: Error {
+        case invalidManufacturerID
+        case payloadTooLong
+        case invalidPacketSequence
+        case wrongMessageType
+    }
+
+    private static let maxChunk = 14
+    private static let maxPayloadLength = 0xFFFF
+
+    /// Fragment a SysEx8 payload into UMP packets.
+    /// - Parameters:
+    ///   - manufacturerID: 1 or 3 byte manufacturer identifier.
+    ///   - payload: SysEx payload bytes excluding manufacturer ID.
+    ///   - group: UMP group (0-15).
+    /// - Returns: Array of 16 byte UMP packets.
+    public static func fragment(manufacturerID: [UInt8], payload: [UInt8], group: UInt8 = 0) throws -> [[UInt8]] {
+        guard isValidManufacturerID(manufacturerID) else { throw StreamError.invalidManufacturerID }
+        guard payload.count <= maxPayloadLength else { throw StreamError.payloadTooLong }
+
+        let message = manufacturerID + payload
+        var packets: [[UInt8]] = []
+        var index = 0
+        let totalChunks = Int(ceil(Double(message.count) / Double(maxChunk)))
+
+        while index < message.count {
+            let remaining = message.count - index
+            let chunkSize = min(maxChunk, remaining)
+            let chunk = Array(message[index..<index+chunkSize])
+            let status: UInt8
+            if totalChunks == 1 {
+                status = 0x0
+            } else if index == 0 {
+                status = 0x1
+            } else if remaining <= maxChunk {
+                status = 0x3
+            } else {
+                status = 0x2
+            }
+            var packet: [UInt8] = [0x50 | (group & 0x0F), (status << 4) | UInt8(chunk.count)]
+            packet.append(contentsOf: chunk)
+            if chunk.count < maxChunk {
+                packet.append(contentsOf: Array(repeating: 0, count: maxChunk - chunk.count))
+            }
+            packets.append(packet)
+            index += chunkSize
+        }
+        return packets
+    }
+
+    /// Reassemble SysEx8 payload from UMP packets.
+    /// - Parameter packets: Array of 16 byte UMP packets.
+    /// - Returns: Manufacturer ID and payload.
+    public static func reassemble(_ packets: [[UInt8]]) throws -> (manufacturerID: [UInt8], payload: [UInt8]) {
+        guard !packets.isEmpty else { throw StreamError.invalidPacketSequence }
+        var bytes: [UInt8] = []
+        for (i, packet) in packets.enumerated() {
+            guard packet.count == 16 else { throw StreamError.invalidPacketSequence }
+            let mt = packet[0] >> 4
+            guard mt == 0x5 else { throw StreamError.wrongMessageType }
+            let status = packet[1] >> 4
+            let count = Int(packet[1] & 0x0F)
+            guard count <= maxChunk else { throw StreamError.invalidPacketSequence }
+            let data = Array(packet[2..<(2 + maxChunk)]).prefix(count)
+            bytes.append(contentsOf: data)
+
+            switch status {
+            case 0x0:
+                if packets.count != 1 { throw StreamError.invalidPacketSequence }
+            case 0x1:
+                if i != 0 { throw StreamError.invalidPacketSequence }
+            case 0x2:
+                if i == 0 || i == packets.count - 1 { throw StreamError.invalidPacketSequence }
+            case 0x3:
+                if i != packets.count - 1 { throw StreamError.invalidPacketSequence }
+            default:
+                throw StreamError.invalidPacketSequence
+            }
+        }
+        guard !bytes.isEmpty else { throw StreamError.invalidPacketSequence }
+        let manufacturerID: [UInt8]
+        let payload: [UInt8]
+        if bytes[0] == 0x00 {
+            guard bytes.count >= 3 else { throw StreamError.invalidManufacturerID }
+            manufacturerID = Array(bytes[0..<3])
+            payload = Array(bytes.dropFirst(3))
+        } else {
+            manufacturerID = [bytes[0]]
+            payload = Array(bytes.dropFirst())
+        }
+        guard isValidManufacturerID(manufacturerID) else { throw StreamError.invalidManufacturerID }
+        return (manufacturerID, payload)
+    }
+
+    private static func isValidManufacturerID(_ id: [UInt8]) -> Bool {
+        if id.count == 1 {
+            return id[0] != 0x00
+        } else if id.count == 3 {
+            return id[0] == 0x00
+        } else {
+            return false
+        }
+    }
+}
+

--- a/Tests/MIDI2Tests/SysEx7PacketTests.swift
+++ b/Tests/MIDI2Tests/SysEx7PacketTests.swift
@@ -2,7 +2,21 @@ import XCTest
 @testable import MIDI2
 
 final class SysEx7PacketTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test SysEx7Packet
+    func testFragmentAndReassemble() throws {
+        let manufacturer: [UInt8] = [0x7D]
+        let payload: [UInt8] = [0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08]
+        let packets = try SysEx7.fragment(manufacturerID: manufacturer, payload: payload)
+        let expected: [[UInt8]] = [
+            [0x30, 0x16, 0x7D, 0x01, 0x02, 0x03, 0x04, 0x05],
+            [0x30, 0x33, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00]
+        ]
+        XCTAssertEqual(packets, expected)
+        let (mfr, reassembled) = try SysEx7.reassemble(packets)
+        XCTAssertEqual(mfr, manufacturer)
+        XCTAssertEqual(reassembled, payload)
+    }
+
+    func testInvalidManufacturer() {
+        XCTAssertThrowsError(try SysEx7.fragment(manufacturerID: [0x00], payload: []))
     }
 }

--- a/Tests/MIDI2Tests/SysEx8Tests.swift
+++ b/Tests/MIDI2Tests/SysEx8Tests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import MIDI2
+
+final class SysEx8Tests: XCTestCase {
+    func testFragmentAndReassemble() throws {
+        let manufacturer: [UInt8] = [0x00, 0x20, 0x33]
+        let payload: [UInt8] = Array(1...20).map { UInt8($0) }
+        let packets = try SysEx8.fragment(manufacturerID: manufacturer, payload: payload)
+        let expected: [[UInt8]] = [
+            [0x50, 0x1E, 0x00, 0x20, 0x33, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B],
+            [0x50, 0x39, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00]
+        ]
+        XCTAssertEqual(packets, expected)
+        let (mfr, reassembled) = try SysEx8.reassemble(packets)
+        XCTAssertEqual(mfr, manufacturer)
+        XCTAssertEqual(reassembled, payload)
+    }
+
+    func testInvalidManufacturer() {
+        XCTAssertThrowsError(try SysEx8.fragment(manufacturerID: [0x01, 0x02], payload: []))
+    }
+}


### PR DESCRIPTION
## Summary
- implement SysEx7 streaming helper with fragmentation and reassembly
- add SysEx8 streaming helper with validation
- cover SysEx7 and SysEx8 with golden vector tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689c1aba18cc833380daf973b991dd96