### PR TITLE
Add FlexData tempo and pitch structs

### DIFF
--- a/Sources/MIDI2/FlexDataPitch.swift
+++ b/Sources/MIDI2/FlexDataPitch.swift
@@ -1,0 +1,33 @@
+/// Flex: Set Pitch (fractional semitone value).
+public struct FlexDataPitch {
+    public var semitones: Double
+
+    public init(semitones: Double) {
+        self.semitones = semitones
+    }
+
+    private static let statusClass: UInt8 = 0x10
+    private static let status: UInt8 = 0x02
+    private static let scale: Double = 65536.0 // 16.16 fixed point
+
+    private var fixedPointValue: UInt32 {
+        UInt32((semitones * Self.scale).rounded())
+    }
+
+    public func encode(group: UInt8 = 0) -> Ump128 {
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8
+        let word1 = fixedPointValue
+        return Ump128(word0: word0, word1: word1, word2: 0, word3: 0)!
+    }
+
+    public static func decode(_ packet: Ump128) -> FlexDataPitch? {
+        guard packet.messageType == 0xD,
+              UInt8((packet.word0 >> 16) & 0xFF) == statusClass,
+              UInt8((packet.word0 >> 8) & 0xFF) == status else { return nil }
+        let semitones = Double(packet.word1) / scale
+        return FlexDataPitch(semitones: semitones)
+    }
+}

--- a/Sources/MIDI2/FlexDataTempo.swift
+++ b/Sources/MIDI2/FlexDataTempo.swift
@@ -1,0 +1,34 @@
+/// Flex: Set Tempo (heuristic mapping to BPM).
+public struct FlexDataTempo {
+    public var beatsPerMinute: Double
+
+    public init(beatsPerMinute: Double) {
+        precondition(beatsPerMinute >= 1, "Tempo must be at least 1 BPM")
+        self.beatsPerMinute = beatsPerMinute
+    }
+
+    private static let statusClass: UInt8 = 0x10
+    private static let status: UInt8 = 0x01
+    private static let scale: Double = 65536.0 // 16.16 fixed point
+
+    private var fixedPointValue: UInt32 {
+        UInt32((beatsPerMinute * Self.scale).rounded())
+    }
+
+    public func encode(group: UInt8 = 0) -> Ump128 {
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8
+        let word1 = fixedPointValue
+        return Ump128(word0: word0, word1: word1, word2: 0, word3: 0)!
+    }
+
+    public static func decode(_ packet: Ump128) -> FlexDataTempo? {
+        guard packet.messageType == 0xD,
+              UInt8((packet.word0 >> 16) & 0xFF) == statusClass,
+              UInt8((packet.word0 >> 8) & 0xFF) == status else { return nil }
+        let bpm = Double(packet.word1) / scale
+        return FlexDataTempo(beatsPerMinute: bpm)
+    }
+}

--- a/Sources/MIDI2/FlexTempo.swift
+++ b/Sources/MIDI2/FlexTempo.swift
@@ -1,3 +1,0 @@
-/// Flex: Set Tempo (heuristic mapping to BPM).
-public struct FlexTempo {
-}

--- a/Tests/MIDI2Tests/FlexDataPitchTests.swift
+++ b/Tests/MIDI2Tests/FlexDataPitchTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexDataPitchTests: XCTestCase {
+    func testRoundTrip() {
+        let original = FlexDataPitch(semitones: 3.5)
+        let packet = original.encode(group: 1)
+        let decoded = FlexDataPitch.decode(packet)
+        XCTAssertNotNil(decoded)
+        if let decoded {
+            XCTAssertEqual(decoded.semitones, original.semitones, accuracy: 0.0001)
+        }
+    }
+
+    func testSemanticEncoding() {
+        let pitch = FlexDataPitch(semitones: 3.5)
+        let packet = pitch.encode()
+        XCTAssertEqual(packet.word1, 0x00038000)
+        guard let decoded = FlexDataPitch.decode(packet) else { return XCTFail("decode failed") }
+        XCTAssertEqual(decoded.semitones, 3.5, accuracy: 0.0001)
+    }
+}

--- a/Tests/MIDI2Tests/FlexDataTempoTests.swift
+++ b/Tests/MIDI2Tests/FlexDataTempoTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexDataTempoTests: XCTestCase {
+    func testRoundTrip() {
+        let original = FlexDataTempo(beatsPerMinute: 123.456)
+        let packet = original.encode(group: 2)
+        let decoded = FlexDataTempo.decode(packet)
+        XCTAssertNotNil(decoded)
+        if let decoded {
+            XCTAssertEqual(decoded.beatsPerMinute, original.beatsPerMinute, accuracy: 0.001)
+        }
+    }
+
+    func testSemanticEncoding() {
+        let tempo = FlexDataTempo(beatsPerMinute: 120)
+        let packet = tempo.encode()
+        XCTAssertEqual(packet.word1, 0x00780000)
+        guard let decoded = FlexDataTempo.decode(packet) else { return XCTFail("decode failed") }
+        XCTAssertEqual(decoded.beatsPerMinute, 120, accuracy: 0.0001)
+    }
+}

--- a/Tests/MIDI2Tests/FlexTempoTests.swift
+++ b/Tests/MIDI2Tests/FlexTempoTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import MIDI2
-
-final class FlexTempoTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexTempo
-    }
-}


### PR DESCRIPTION
## Summary
- implement `FlexDataTempo` with BPM ↔︎ 16.16 fixed-point encode/decode
- add `FlexDataPitch` for fractional semitone values and UMP conversion
- provide round-trip and semantic tests for tempo and pitch flex data

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689c1c9682148333af30fef79951b5e6