### PR TITLE
Add basic MIDI-CI handshake models and tests

### DIFF
--- a/Sources/MIDI2CI/CIHandshake.swift
+++ b/Sources/MIDI2CI/CIHandshake.swift
@@ -1,0 +1,34 @@
+/// Helper APIs for initiating and responding to MIDI-CI handshakes.
+public enum CIHandshake {
+    /// Create a protocol negotiation request listing the initiator's supported protocols.
+    public static func initiateProtocolNegotiation(supported: [MidiCIProtocol]) -> ProtocolNegotiationRequest {
+        ProtocolNegotiationRequest(supportedProtocols: supported)
+    }
+
+    /// Generate a protocol negotiation response from the responder's supported protocols.
+    public static func respond(to request: ProtocolNegotiationRequest, supported: [MidiCIProtocol]) -> ProtocolNegotiationResponse {
+        let agreed = supported.first { request.supportedProtocols.contains($0) }
+        return ProtocolNegotiationResponse(acceptedProtocol: agreed)
+    }
+
+    /// Create a profile inquiry request for a specific profile identifier.
+    public static func initiateProfileInquiry(profile: String) -> ProfileInquiryRequest {
+        ProfileInquiryRequest(profile: profile)
+    }
+
+    /// Respond to a profile inquiry request by indicating profile support.
+    public static func respond(to request: ProfileInquiryRequest, supportedProfiles: [String]) -> ProfileInquiryResponse {
+        ProfileInquiryResponse(supported: supportedProfiles.contains(request.profile))
+    }
+
+    /// Create a property exchange GET request for a resource URI.
+    public static func initiatePropertyGet(resource: String) -> PropertyExchangeGetRequest {
+        PropertyExchangeGetRequest(resource: resource)
+    }
+
+    /// Respond to a property exchange GET request using a dictionary of properties.
+    public static func respond(to request: PropertyExchangeGetRequest, properties: [String: String]) -> PropertyExchangeGetResponse {
+        let value = properties[request.resource]
+        return PropertyExchangeGetResponse(resource: request.resource, value: value)
+    }
+}

--- a/Sources/MIDI2CI/Placeholder.swift
+++ b/Sources/MIDI2CI/Placeholder.swift
@@ -1,1 +1,0 @@
-public struct MIDI2CIPlaceholder {}

--- a/Sources/MIDI2CI/ProfileInquiry.swift
+++ b/Sources/MIDI2CI/ProfileInquiry.swift
@@ -1,0 +1,12 @@
+/// Profile inquiry packets based on models from `midi2.full.openapi.json`.
+public struct ProfileInquiryRequest: Codable {
+    /// Identifier of the profile being queried.
+    public var profile: String
+    public init(profile: String) { self.profile = profile }
+}
+
+public struct ProfileInquiryResponse: Codable {
+    /// Indicates whether the responder supports the requested profile.
+    public var supported: Bool
+    public init(supported: Bool) { self.supported = supported }
+}

--- a/Sources/MIDI2CI/PropertyExchange.swift
+++ b/Sources/MIDI2CI/PropertyExchange.swift
@@ -1,0 +1,17 @@
+/// Property exchange packets modelled after `midi2.full.openapi.json` definitions.
+public struct PropertyExchangeGetRequest: Codable {
+    /// URI of the property being requested.
+    public var resource: String
+    public init(resource: String) { self.resource = resource }
+}
+
+public struct PropertyExchangeGetResponse: Codable {
+    /// URI of the property.
+    public var resource: String
+    /// Optional value returned by the responder.
+    public var value: String?
+    public init(resource: String, value: String?) {
+        self.resource = resource
+        self.value = value
+    }
+}

--- a/Sources/MIDI2CI/ProtocolNegotiation.swift
+++ b/Sources/MIDI2CI/ProtocolNegotiation.swift
@@ -1,0 +1,21 @@
+/// Protocol negotiation request/response models derived from `midi2.full.openapi.json`.
+public enum MidiCIProtocol: UInt8, Codable, CaseIterable {
+    case midi1 = 1
+    case midi2 = 2
+}
+
+/// Request packet listing supported protocols.
+public struct ProtocolNegotiationRequest: Codable {
+    public var supportedProtocols: [MidiCIProtocol]
+    public init(supportedProtocols: [MidiCIProtocol]) {
+        self.supportedProtocols = supportedProtocols
+    }
+}
+
+/// Response packet indicating the protocol accepted by the responder.
+public struct ProtocolNegotiationResponse: Codable {
+    public var acceptedProtocol: MidiCIProtocol?
+    public init(acceptedProtocol: MidiCIProtocol?) {
+        self.acceptedProtocol = acceptedProtocol
+    }
+}

--- a/Tests/MIDI2Tests/MidiCiHandshakeIntegrationTests.swift
+++ b/Tests/MIDI2Tests/MidiCiHandshakeIntegrationTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import MIDI2CI
+
+final class MidiCiHandshakeIntegrationTests: XCTestCase {
+    func testProtocolNegotiationFlow() {
+        let request = CIHandshake.initiateProtocolNegotiation(supported: [.midi2, .midi1])
+        let response = CIHandshake.respond(to: request, supported: [.midi2])
+        XCTAssertEqual(response.acceptedProtocol, .midi2)
+    }
+
+    func testProfileInquiryFlow() {
+        let request = CIHandshake.initiateProfileInquiry(profile: "com.example.profile")
+        let response = CIHandshake.respond(to: request, supportedProfiles: ["com.example.profile"])
+        XCTAssertTrue(response.supported)
+    }
+
+    func testPropertyExchangeFlow() {
+        let request = CIHandshake.initiatePropertyGet(resource: "example")
+        let response = CIHandshake.respond(to: request, properties: ["example": "value"])
+        XCTAssertEqual(response.value, "value")
+    }
+}


### PR DESCRIPTION
## Summary
- model Protocol Negotiation, Profile Inquiry, and Property Exchange packets
- expose helper APIs for MIDI-CI initiator/responder handshakes
- add integration tests covering negotiation, inquiry, and property flows

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689c1e37955883338cebf97ed5e98485