### PR TITLE
Add error handling and fuzz tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "db38be34e87d3097c0815afd462b9bf972be6122a5756f0227ea7995ceb92b91",
+  "pins" : [
+    {
+      "identity" : "chalk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Chalk.git",
+      "state" : {
+        "revision" : "a7f58e47a08ca5a84f73acc4bcf6c2c19d990609",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "filecheck",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/llvm-swift/FileCheck.git",
+      "state" : {
+        "revision" : "f7c5f1a9479b33a876a6f5632ca2b92a7ce4b667",
+        "version" : "0.2.6"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swiftcheck",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/typelift/SwiftCheck.git",
+      "state" : {
+        "revision" : "077c096c3ddfc38db223ac8e525ad16ffb987138",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,13 @@ let package = Package(
         .library(name: "MIDI2", targets: ["MIDI2"]),
         .library(name: "MIDI2CI", targets: ["MIDI2CI"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/typelift/SwiftCheck.git", from: "0.12.0")
+    ],
     targets: [
         .target(name: "MIDI2"),
         .target(name: "MIDI2CI", dependencies: ["MIDI2"]),
-        .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2", "MIDI2CI"])
+        .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2", "MIDI2CI"]),
+        .testTarget(name: "Fuzz", dependencies: ["MIDI2", "SwiftCheck"], path: "Tests/Fuzz")
     ]
 )

--- a/Sources/MIDI2/MIDIError.swift
+++ b/Sources/MIDI2/MIDIError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum MIDIError: LocalizedError {
+    case valueOutOfRange(name: String, value: UInt64, range: ClosedRange<UInt64>)
+    case malformedPacket(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .valueOutOfRange(name, value, range):
+            return "\(name) value \(value) out of range \(range.lowerBound)...\(range.upperBound)"
+        case .malformedPacket(let reason):
+            return "Malformed packet: \(reason)"
+        }
+    }
+}

--- a/Sources/MIDI2/Midi1ChannelVoiceBody.swift
+++ b/Sources/MIDI2/Midi1ChannelVoiceBody.swift
@@ -73,6 +73,51 @@ public extension Midi1ChannelVoiceMessage {
         }
     }
 
+    init(parsingUMP ump: UmpPacket32) throws {
+        let mt = UInt8((ump.word >> 28) & 0xF)
+        guard mt == 0x2 else {
+            throw MIDIError.malformedPacket("expected mt 0x2 but got \(mt)")
+        }
+        let group = try Uint4(validating: UInt8((ump.word >> 24) & 0xF))
+        let statusByte = UInt8((ump.word >> 16) & 0xFF)
+        let statusNibble = statusByte >> 4
+        guard let status = Midi1StatusNibble(statusNibble) else {
+            throw MIDIError.malformedPacket("invalid status nibble 0x\(String(statusNibble, radix: 16))")
+        }
+        let channel = try Uint4(validating: statusByte & 0x0F)
+        let data1 = UInt8((ump.word >> 8) & 0xFF)
+        let data2 = UInt8(ump.word & 0xFF)
+
+        switch status {
+        case .noteOff:
+            let note = try Uint7(validating: data1)
+            let velocity = try Uint7(validating: data2)
+            self = .noteOff(group: group, channel: channel, note: note, velocity: velocity)
+        case .noteOn:
+            let note = try Uint7(validating: data1)
+            let velocity = try Uint7(validating: data2)
+            self = .noteOn(group: group, channel: channel, note: note, velocity: velocity)
+        case .polyPressure:
+            let note = try Uint7(validating: data1)
+            let pressure = try Uint7(validating: data2)
+            self = .polyPressure(group: group, channel: channel, note: note, pressure: pressure)
+        case .controlChange:
+            let control = try Uint7(validating: data1)
+            let value = try Uint7(validating: data2)
+            self = .controlChange(group: group, channel: channel, control: control, value: value)
+        case .programChange:
+            let program = try Uint7(validating: data1)
+            self = .programChange(group: group, channel: channel, program: program)
+        case .channelPressure:
+            let pressure = try Uint7(validating: data1)
+            self = .channelPressure(group: group, channel: channel, pressure: pressure)
+        case .pitchBend:
+            let value14 = UInt16(data2) << 7 | UInt16(data1)
+            let bend = try Uint14(validating: value14)
+            self = .pitchBend(group: group, channel: channel, value: bend)
+        }
+    }
+
     func midi1Bytes() -> [UInt8] {
         switch self {
         case let .noteOff(_, channel, note, velocity):
@@ -125,6 +170,49 @@ public extension Midi1ChannelVoiceMessage {
         case .pitchBend:
             let value14 = UInt16(data2) << 7 | UInt16(data1)
             guard let bend = Uint14(value14) else { return nil }
+            self = .pitchBend(group: group, channel: channel, value: bend)
+        }
+    }
+
+    init(parsingMidi1Bytes bytes: [UInt8], group: Uint4) throws {
+        guard bytes.count >= 2 else {
+            throw MIDIError.malformedPacket("MIDI 1 Channel Voice requires at least 2 bytes")
+        }
+        let statusByte = bytes[0]
+        let statusNibble = statusByte >> 4
+        guard let status = Midi1StatusNibble(statusNibble) else {
+            throw MIDIError.malformedPacket("invalid status nibble 0x\(String(statusNibble, radix: 16))")
+        }
+        let channel = try Uint4(validating: statusByte & 0x0F)
+        let data1 = bytes[1]
+        let data2: UInt8 = bytes.count > 2 ? bytes[2] : 0
+
+        switch status {
+        case .noteOff:
+            let note = try Uint7(validating: data1)
+            let velocity = try Uint7(validating: data2)
+            self = .noteOff(group: group, channel: channel, note: note, velocity: velocity)
+        case .noteOn:
+            let note = try Uint7(validating: data1)
+            let velocity = try Uint7(validating: data2)
+            self = .noteOn(group: group, channel: channel, note: note, velocity: velocity)
+        case .polyPressure:
+            let note = try Uint7(validating: data1)
+            let pressure = try Uint7(validating: data2)
+            self = .polyPressure(group: group, channel: channel, note: note, pressure: pressure)
+        case .controlChange:
+            let control = try Uint7(validating: data1)
+            let value = try Uint7(validating: data2)
+            self = .controlChange(group: group, channel: channel, control: control, value: value)
+        case .programChange:
+            let program = try Uint7(validating: data1)
+            self = .programChange(group: group, channel: channel, program: program)
+        case .channelPressure:
+            let pressure = try Uint7(validating: data1)
+            self = .channelPressure(group: group, channel: channel, pressure: pressure)
+        case .pitchBend:
+            let value14 = UInt16(data2) << 7 | UInt16(data1)
+            let bend = try Uint14(validating: value14)
             self = .pitchBend(group: group, channel: channel, value: bend)
         }
     }

--- a/Sources/MIDI2/System/SystemCommon.swift
+++ b/Sources/MIDI2/System/SystemCommon.swift
@@ -74,4 +74,35 @@ public enum SystemCommon: Equatable {
             return nil
         }
     }
+
+    public init(parsingUMP ump: UmpPacket32) throws {
+        let mt = UInt8((ump.word >> 28) & 0xF)
+        guard mt == 0x1 else {
+            throw MIDIError.malformedPacket("expected mt 0x1 but got \(mt)")
+        }
+        let byte0 = UInt8((ump.word >> 24) & 0xFF)
+        let group = try Uint4(validating: byte0 & 0x0F)
+        let status = UInt8((ump.word >> 16) & 0xFF)
+        guard status >> 4 == 0xF else {
+            throw MIDIError.malformedPacket("invalid system common status 0x\(String(status, radix: 16))")
+        }
+        let data1 = UInt8((ump.word >> 8) & 0xFF)
+        let data2 = UInt8(ump.word & 0xFF)
+        switch status {
+        case 0xF1:
+            let msg = try Uint7(validating: data1)
+            self = .mtcQuarterFrame(group: group, message: msg)
+        case 0xF2:
+            let value = UInt16(data1 & 0x7F) | (UInt16(data2 & 0x7F) << 7)
+            let pos = try Uint14(validating: value)
+            self = .songPositionPointer(group: group, position: pos)
+        case 0xF3:
+            let song = try Uint7(validating: data1)
+            self = .songSelect(group: group, song: song)
+        case 0xF6:
+            self = .tuneRequest(group: group)
+        default:
+            throw MIDIError.malformedPacket("unsupported system common status 0x\(String(status, radix: 16))")
+        }
+    }
 }

--- a/Sources/MIDI2/System/Utility.swift
+++ b/Sources/MIDI2/System/Utility.swift
@@ -48,4 +48,27 @@ public enum Utility: Equatable {
             return nil
         }
     }
+
+    public init(parsingUMP ump: UmpPacket32) throws {
+        let mt = UInt8((ump.word >> 28) & 0xF)
+        guard mt == 0x0 else {
+            throw MIDIError.malformedPacket("expected mt 0x0 but got \(mt)")
+        }
+        let byte0 = UInt8((ump.word >> 24) & 0xFF)
+        guard (byte0 & 0x0F) == 0 else {
+            throw MIDIError.malformedPacket("utility messages must have group nibble 0")
+        }
+        let status = UInt8((ump.word >> 16) & 0xFF)
+        let data = UInt16(ump.word & 0xFFFF)
+        switch status {
+        case 0x00:
+            self = .noop
+        case 0x01:
+            self = .jrClock(data)
+        case 0x02:
+            self = .jrTimestamp(data)
+        default:
+            throw MIDIError.malformedPacket("unsupported utility status 0x\(String(status, radix: 16))")
+        }
+    }
 }

--- a/Sources/MIDI2/Uint14.swift
+++ b/Sources/MIDI2/Uint14.swift
@@ -5,4 +5,11 @@ public struct Uint14: Equatable, Hashable {
         guard rawValue < 0x4000 else { return nil }
         self.rawValue = rawValue
     }
+
+    public init(validating rawValue: UInt16) throws {
+        guard rawValue < 0x4000 else {
+            throw MIDIError.valueOutOfRange(name: "Uint14", value: UInt64(rawValue), range: 0...0x3FFF)
+        }
+        self.rawValue = rawValue
+    }
 }

--- a/Sources/MIDI2/Uint4.swift
+++ b/Sources/MIDI2/Uint4.swift
@@ -5,4 +5,11 @@ public struct Uint4: Equatable, Hashable {
         guard rawValue < 0x10 else { return nil }
         self.rawValue = rawValue
     }
+
+    public init(validating rawValue: UInt8) throws {
+        guard rawValue < 0x10 else {
+            throw MIDIError.valueOutOfRange(name: "Uint4", value: UInt64(rawValue), range: 0...0xF)
+        }
+        self.rawValue = rawValue
+    }
 }

--- a/Sources/MIDI2/Uint7.swift
+++ b/Sources/MIDI2/Uint7.swift
@@ -5,4 +5,11 @@ public struct Uint7: Equatable, Hashable {
         guard rawValue < 0x80 else { return nil }
         self.rawValue = rawValue
     }
+
+    public init(validating rawValue: UInt8) throws {
+        guard rawValue < 0x80 else {
+            throw MIDIError.valueOutOfRange(name: "Uint7", value: UInt64(rawValue), range: 0...0x7F)
+        }
+        self.rawValue = rawValue
+    }
 }

--- a/Tests/Fuzz/Uint7FuzzTests.swift
+++ b/Tests/Fuzz/Uint7FuzzTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+import SwiftCheck
+@testable import MIDI2
+
+final class Uint7FuzzTests: XCTestCase {
+    func testUint7Range() {
+        property("Uint7 validates range") <- forAll { (x: UInt8) in
+            if x < 0x80 {
+                return (try? Uint7(validating: x)) != nil
+            } else {
+                return (try? Uint7(validating: x)) == nil
+            }
+        }
+    }
+}

--- a/Tests/MIDI2Tests/ChannelVoice/ChannelVoiceErrorTests.swift
+++ b/Tests/MIDI2Tests/ChannelVoice/ChannelVoiceErrorTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import MIDI2
+
+final class ChannelVoiceErrorTests: XCTestCase {
+    func testNoteOnOutOfRangeNote() {
+        let bytes: [UInt8] = [0x90, 0xFF, 0x40]
+        let group = Uint4(0x0)!
+        XCTAssertThrowsError(try Midi1ChannelVoiceMessage(parsingMidi1Bytes: bytes, group: group)) { error in
+            XCTAssertEqual(error.localizedDescription, "Uint7 value 255 out of range 0...127")
+        }
+    }
+
+    func testInvalidStatusNibble() {
+        let bytes: [UInt8] = [0xF0, 0x00]
+        let group = Uint4(0x0)!
+        XCTAssertThrowsError(try Midi1ChannelVoiceMessage(parsingMidi1Bytes: bytes, group: group)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("invalid status nibble"))
+        }
+    }
+}

--- a/Tests/MIDI2Tests/System/SystemCommonErrorTests.swift
+++ b/Tests/MIDI2Tests/System/SystemCommonErrorTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import MIDI2
+
+final class SystemCommonErrorTests: XCTestCase {
+    func testUnsupportedStatus() {
+        let byte0 = UInt32(0x1 << 4 | 0x1)
+        let status = UInt32(0xF4)
+        let word = (byte0 << 24) | (status << 16)
+        let ump = UmpPacket32(word: word)
+        XCTAssertThrowsError(try SystemCommon(parsingUMP: ump)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("unsupported system common status"))
+        }
+    }
+}

--- a/Tests/MIDI2Tests/System/UtilityErrorTests.swift
+++ b/Tests/MIDI2Tests/System/UtilityErrorTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import MIDI2
+
+final class UtilityErrorTests: XCTestCase {
+    func testUnsupportedStatus() {
+        let byte0 = UInt32(0x0 << 4)
+        let word = (byte0 << 24) | (UInt32(0x03) << 16)
+        let ump = UmpPacket32(word: word)
+        XCTAssertThrowsError(try Utility(parsingUMP: ump)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("unsupported utility status"))
+        }
+    }
+
+    func testNonZeroGroupNibble() {
+        let byte0 = UInt32(0x0 << 4 | 0x1)
+        let word = (byte0 << 24)
+        let ump = UmpPacket32(word: word)
+        XCTAssertThrowsError(try Utility(parsingUMP: ump)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("group nibble"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MIDIError with descriptive failure cases
- validate UInt wrappers and message parsers with thrown errors
- introduce negative and fuzz tests for message families

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689c1f407fe88333ad45940db121288d