### PR TITLE
Implement Midi2 note-on and packet utilities

### DIFF
--- a/Sources/MIDI2/Midi2NoteOn.swift
+++ b/Sources/MIDI2/Midi2NoteOn.swift
@@ -1,3 +1,71 @@
 /// Status 0x9 (Note On).
-public struct Midi2NoteOn {
+///
+/// Represents a MIDI 2.0 Channel Voice "Note On" message. This message is
+/// encoded as a 64-bit Universal MIDI Packet with the following layout:
+///
+/// ```
+/// Word0: [MT=0x4][Group][Status=0x9][Channel][Note][Attribute Type]
+/// Word1: [Velocity (16 bits)][Attribute Data (16 bits)]
+/// ```
+public struct Midi2NoteOn: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let note: Uint7
+    public let velocity: UInt16
+    public let attributeType: NoteAttributeType
+    public let attributeData: UInt16
+
+    /// Creates a new Note On message.
+    public init(group: Uint4, channel: Uint4, note: Uint7, velocity: UInt16, attributeType: NoteAttributeType = .none, attributeData: UInt16 = 0) {
+        self.group = group
+        self.channel = channel
+        self.note = note
+        self.velocity = velocity
+        self.attributeType = attributeType
+        self.attributeData = attributeData
+    }
+
+    /// Encodes this message into a 64-bit Universal MIDI Packet.
+    public func ump() -> UmpPacket64 {
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(0x9) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(note.rawValue) << 8 |
+                    UInt32(attributeType.rawValue)
+        let word1 = UInt32(velocity) << 16 | UInt32(attributeData)
+        return UmpPacket64(word0: word0, word1: word1)
+    }
+
+    /// Creates a Note On message from a Universal MIDI Packet.
+    /// Returns `nil` if the packet does not encode a Note On.
+    public init?(ump: UmpPacket64) {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        guard ((ump.word0 >> 20) & 0xF) == 0x9 else { return nil }
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        guard let note = Uint7(UInt8((ump.word0 >> 8) & 0xFF)) else { return nil }
+        let attrType = NoteAttributeType(UInt8(ump.word0 & 0xFF))
+        let velocity = UInt16((ump.word1 >> 16) & 0xFFFF)
+        let attrData = UInt16(ump.word1 & 0xFFFF)
+        self.init(group: group, channel: channel, note: note, velocity: velocity, attributeType: attrType, attributeData: attrData)
+    }
+
+    /// Parses a Universal MIDI Packet into a Note On message.
+    /// Throws `MIDIError.malformedPacket` if the packet is not a Note On message.
+    public init(parsingUMP ump: UmpPacket64) throws {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else {
+            throw MIDIError.malformedPacket("expected mt 0x4 but got \(((ump.word0 >> 28) & 0xF))")
+        }
+        guard ((ump.word0 >> 20) & 0xF) == 0x9 else {
+            throw MIDIError.malformedPacket("expected status 0x9 but got \(((ump.word0 >> 20) & 0xF))")
+        }
+        let group = try Uint4(validating: UInt8((ump.word0 >> 24) & 0xF))
+        let channel = try Uint4(validating: UInt8((ump.word0 >> 16) & 0xF))
+        let note = try Uint7(validating: UInt8((ump.word0 >> 8) & 0xFF))
+        let attrType = NoteAttributeType(UInt8(ump.word0 & 0xFF))
+        let velocity = UInt16((ump.word1 >> 16) & 0xFFFF)
+        let attrData = UInt16(ump.word1 & 0xFFFF)
+        self.init(group: group, channel: channel, note: note, velocity: velocity, attributeType: attrType, attributeData: attrData)
+    }
 }

--- a/Sources/MIDI2/UmpPacket64.swift
+++ b/Sources/MIDI2/UmpPacket64.swift
@@ -1,3 +1,25 @@
 /// 64-bit Universal MIDI Packet consisting of two 32-bit words.
-public struct UmpPacket64 {
+public struct UmpPacket64: Equatable, UniversalPacket {
+    /// The first 32-bit word of the packet.
+    public let word0: UInt32
+    /// The second 32-bit word of the packet.
+    public let word1: UInt32
+
+    /// Number of 32-bit words in this packet.
+    public static let wordCount: Int = 2
+
+    /// Creates a packet from two raw 32-bit words.
+    public init(word0: UInt32, word1: UInt32) {
+        self.word0 = word0
+        self.word1 = word1
+    }
+
+    /// Creates a packet from an array of two 32-bit words.
+    public init?(words: [UInt32]) {
+        guard words.count == 2 else { return nil }
+        self.init(word0: words[0], word1: words[1])
+    }
+
+    /// Returns the raw 32-bit words making up this packet.
+    public var words: [UInt32] { [word0, word1] }
 }

--- a/Tests/MIDI2Tests/Midi2NoteOnTests.swift
+++ b/Tests/MIDI2Tests/Midi2NoteOnTests.swift
@@ -2,7 +2,25 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2NoteOnTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2NoteOn
+    func testRoundTrip() {
+        let group = Uint4(0x1)!
+        let channel = Uint4(0x2)!
+        let note = Uint7(60)!
+        let msg = Midi2NoteOn(group: group, channel: channel, note: note, velocity: 0x1234, attributeType: .none, attributeData: 0x5678)
+        let packet = msg.ump()
+        guard let parsed = Midi2NoteOn(ump: packet) else {
+            return XCTFail("failed to parse packet")
+        }
+        XCTAssertEqual(parsed, msg)
+    }
+
+    func testInvalidStatusReturnsNil() {
+        let packet = UmpPacket64(word0: 0, word1: 0)
+        XCTAssertNil(Midi2NoteOn(ump: packet))
+    }
+
+    func testParsingThrowsForWrongMessageType() {
+        let packet = UmpPacket64(word0: UInt32(0x5 << 28), word1: 0)
+        XCTAssertThrowsError(try Midi2NoteOn(parsingUMP: packet))
     }
 }

--- a/Tests/MIDI2Tests/UmpPacket32Tests.swift
+++ b/Tests/MIDI2Tests/UmpPacket32Tests.swift
@@ -2,7 +2,21 @@ import XCTest
 @testable import MIDI2
 
 final class UmpPacket32Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UmpPacket32
+    func testMidi1NoteOnRoundtrip() {
+        let bytes: [UInt8] = [0x90, 0x40, 0x7F]
+        let group = Uint4(0x2)!
+        guard let packet = UmpPacket32(midi1Bytes: bytes, group: group) else {
+            return XCTFail("failed to construct packet")
+        }
+        XCTAssertEqual(packet.midi1Bytes(), bytes)
+    }
+
+    func testProgramChangeRoundtrip() {
+        let bytes: [UInt8] = [0xC3, 0x22]
+        let group = Uint4(0x1)!
+        guard let packet = UmpPacket32(midi1Bytes: bytes, group: group) else {
+            return XCTFail("failed to construct packet")
+        }
+        XCTAssertEqual(packet.midi1Bytes(), bytes)
     }
 }


### PR DESCRIPTION
## Summary
- add `UmpPacket64` to model 64-bit Universal MIDI Packets
- implement `Midi2NoteOn` with encoding/decoding helpers
- cover basic MIDI 1 and MIDI 2 packet round-trips in tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689ca211434883338a08176c281e5e49