### PR TITLE
Implement integer wrappers and validation tests

### DIFF
--- a/Sources/MIDI2/ByteArray.swift
+++ b/Sources/MIDI2/ByteArray.swift
@@ -1,3 +1,30 @@
 /// Convenience wrapper for an array of bytes.
-public struct ByteArray {
+public struct ByteArray: Equatable, Hashable {
+    public let rawValue: [Swift.UInt8]
+
+    public init(_ rawValue: [Swift.UInt8]) {
+        self.rawValue = rawValue
+    }
+
+    public init?(_ rawValue: [Swift.UInt16]) {
+        var bytes: [Swift.UInt8] = []
+        bytes.reserveCapacity(rawValue.count)
+        for b in rawValue {
+            guard b <= 0xFF else { return nil }
+            bytes.append(Swift.UInt8(b))
+        }
+        self.rawValue = bytes
+    }
+
+    public init(validating rawValue: [Swift.UInt16]) throws {
+        var bytes: [Swift.UInt8] = []
+        bytes.reserveCapacity(rawValue.count)
+        for b in rawValue {
+            guard b <= 0xFF else {
+                throw MIDIError.valueOutOfRange(name: "ByteArray", value: Swift.UInt64(b), range: 0...0xFF)
+            }
+            bytes.append(Swift.UInt8(b))
+        }
+        self.rawValue = bytes
+    }
 }

--- a/Sources/MIDI2/Group.swift
+++ b/Sources/MIDI2/Group.swift
@@ -1,3 +1,16 @@
 /// MIDI Group (0-15). Utility (0x0) and Stream (0xF) are groupless in v1.1+; set 0.
-public struct Group {
+public struct Group: Equatable, Hashable {
+    public let rawValue: Swift.UInt8
+
+    public init?(_ rawValue: Swift.UInt8) {
+        guard rawValue < 0x10 else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: Swift.UInt8) throws {
+        guard rawValue < 0x10 else {
+            throw MIDIError.valueOutOfRange(name: "Group", value: Swift.UInt64(rawValue), range: 0...0xF)
+        }
+        self.rawValue = rawValue
+    }
 }

--- a/Sources/MIDI2/Int32.swift
+++ b/Sources/MIDI2/Int32.swift
@@ -1,3 +1,20 @@
 /// Signed 32-bit integer value as defined in the MIDI 2.0 schema.
-public struct Int32 {
+public struct Int32: Equatable, Hashable {
+    public let rawValue: Swift.Int32
+
+    public init?(_ rawValue: Swift.Int64) {
+        guard rawValue >= Swift.Int64(Swift.Int32.min) && rawValue <= Swift.Int64(Swift.Int32.max) else { return nil }
+        self.rawValue = Swift.Int32(rawValue)
+    }
+
+    public init(validating rawValue: Swift.Int64) throws {
+        let min = Swift.Int64(Swift.Int32.min)
+        let max = Swift.Int64(Swift.Int32.max)
+        guard rawValue >= min && rawValue <= max else {
+            let range: ClosedRange<Swift.UInt64> = 0...0xFFFF_FFFF
+            throw MIDIError.valueOutOfRange(name: "Int32", value: Swift.UInt64(bitPattern: rawValue), range: range)
+        }
+        self.rawValue = Swift.Int32(rawValue)
+    }
 }
+

--- a/Sources/MIDI2/Uint16.swift
+++ b/Sources/MIDI2/Uint16.swift
@@ -1,3 +1,16 @@
-/// Unsigned 16-bit integer value (0-65535) as defined in the MIDI 2.0 schema.
-public struct Uint16 {
+/// Unsigned 16-bit integer value (0-65_535) as defined in the MIDI 2.0 schema.
+public struct Uint16: Equatable, Hashable {
+    public let rawValue: Swift.UInt16
+
+    public init?(_ rawValue: Swift.UInt32) {
+        guard rawValue <= 0xFFFF else { return nil }
+        self.rawValue = Swift.UInt16(rawValue)
+    }
+
+    public init(validating rawValue: Swift.UInt32) throws {
+        guard rawValue <= 0xFFFF else {
+            throw MIDIError.valueOutOfRange(name: "Uint16", value: Swift.UInt64(rawValue), range: 0...0xFFFF)
+        }
+        self.rawValue = Swift.UInt16(rawValue)
+    }
 }

--- a/Sources/MIDI2/Uint21.swift
+++ b/Sources/MIDI2/Uint21.swift
@@ -1,3 +1,16 @@
 /// Unsigned 21-bit integer value (0-2_097_151) as defined in the MIDI 2.0 schema.
-public struct Uint21 {
+public struct Uint21: Equatable, Hashable {
+    public let rawValue: Swift.UInt32
+
+    public init?(_ rawValue: Swift.UInt32) {
+        guard rawValue < 0x20_0000 else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: Swift.UInt32) throws {
+        guard rawValue < 0x20_0000 else {
+            throw MIDIError.valueOutOfRange(name: "Uint21", value: Swift.UInt64(rawValue), range: 0...0x1F_FFFF)
+        }
+        self.rawValue = rawValue
+    }
 }

--- a/Sources/MIDI2/Uint28.swift
+++ b/Sources/MIDI2/Uint28.swift
@@ -1,3 +1,16 @@
 /// Unsigned 28-bit integer value (0-268_435_455) as defined in the MIDI 2.0 schema.
-public struct Uint28 {
+public struct Uint28: Equatable, Hashable {
+    public let rawValue: Swift.UInt32
+
+    public init?(_ rawValue: Swift.UInt32) {
+        guard rawValue < 0x1_0000_000 else { return nil } // 0x10000000
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: Swift.UInt32) throws {
+        guard rawValue < 0x1_0000_000 else {
+            throw MIDIError.valueOutOfRange(name: "Uint28", value: Swift.UInt64(rawValue), range: 0...0x0FFF_FFFF)
+        }
+        self.rawValue = rawValue
+    }
 }

--- a/Sources/MIDI2/Uint32.swift
+++ b/Sources/MIDI2/Uint32.swift
@@ -1,3 +1,16 @@
 /// Unsigned 32-bit integer value (0-4_294_967_295) as defined in the MIDI 2.0 schema.
-public struct Uint32 {
+public struct Uint32: Equatable, Hashable {
+    public let rawValue: Swift.UInt32
+
+    public init?(_ rawValue: Swift.UInt64) {
+        guard rawValue <= 0xFFFF_FFFF else { return nil }
+        self.rawValue = Swift.UInt32(rawValue)
+    }
+
+    public init(validating rawValue: Swift.UInt64) throws {
+        guard rawValue <= 0xFFFF_FFFF else {
+            throw MIDIError.valueOutOfRange(name: "Uint32", value: rawValue, range: 0...0xFFFF_FFFF)
+        }
+        self.rawValue = Swift.UInt32(rawValue)
+    }
 }

--- a/Sources/MIDI2/Uint8.swift
+++ b/Sources/MIDI2/Uint8.swift
@@ -1,3 +1,16 @@
 /// Unsigned 8-bit integer value (0-255) as defined in the MIDI 2.0 schema.
-public struct Uint8 {
+public struct Uint8: Equatable, Hashable {
+    public let rawValue: Swift.UInt8
+
+    public init?(_ rawValue: Swift.UInt16) {
+        guard rawValue <= 0xFF else { return nil }
+        self.rawValue = Swift.UInt8(rawValue)
+    }
+
+    public init(validating rawValue: Swift.UInt16) throws {
+        guard rawValue <= 0xFF else {
+            throw MIDIError.valueOutOfRange(name: "Uint8", value: Swift.UInt64(rawValue), range: 0...0xFF)
+        }
+        self.rawValue = Swift.UInt8(rawValue)
+    }
 }

--- a/Tests/MIDI2Tests/ByteArrayTests.swift
+++ b/Tests/MIDI2Tests/ByteArrayTests.swift
@@ -2,7 +2,31 @@ import XCTest
 @testable import MIDI2
 
 final class ByteArrayTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test ByteArray
+    func testRoundTrip() throws {
+        let raw: [UInt16] = [0x00, 0x7F, 0xFF]
+        let arr = try XCTUnwrap(ByteArray(raw))
+        XCTAssertEqual(arr.rawValue, [0x00, 0x7F, 0xFF])
+    }
+
+    func testError() {
+        XCTAssertNil(ByteArray([0x100]))
+        XCTAssertThrowsError(try ByteArray(validating: [0x100]))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<100 {
+            let length = Int.random(in: 0...50)
+            let bytes = (0..<length).map { _ in UInt16.random(in: 0...0xFF) }
+            let arr = try ByteArray(validating: bytes)
+            XCTAssertEqual(arr.rawValue.count, length)
+        }
+
+        for _ in 0..<100 {
+            let length = Int.random(in: 1...50)
+            var bytes = (0..<(length - 1)).map { _ in UInt16.random(in: 0...0xFF) }
+            bytes.append(UInt16.random(in: 0x100...UInt16.max))
+            XCTAssertNil(ByteArray(bytes))
+            XCTAssertThrowsError(try ByteArray(validating: bytes))
+        }
     }
 }

--- a/Tests/MIDI2Tests/GroupTests.swift
+++ b/Tests/MIDI2Tests/GroupTests.swift
@@ -2,7 +2,27 @@ import XCTest
 @testable import MIDI2
 
 final class GroupTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Group
+    func testRoundTrip() throws {
+        let group = try XCTUnwrap(Group(0x7))
+        XCTAssertEqual(group.rawValue, 0x7)
+    }
+
+    func testError() {
+        XCTAssertNil(Group(0x10))
+        XCTAssertThrowsError(try Group(validating: 0x10))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt8.random(in: 0...0xF)
+            let group = try Group(validating: raw)
+            XCTAssertEqual(group.rawValue, raw)
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt8.random(in: 0x10...UInt8.max)
+            XCTAssertNil(Group(raw))
+            XCTAssertThrowsError(try Group(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/Int32Tests.swift
+++ b/Tests/MIDI2Tests/Int32Tests.swift
@@ -2,7 +2,37 @@ import XCTest
 @testable import MIDI2
 
 final class Int32Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Int32
+    func testRoundTrip() throws {
+        let value: Int64 = 123_456
+        let int = try XCTUnwrap(MIDI2.Int32(value))
+        XCTAssertEqual(int.rawValue, 123_456)
+    }
+
+    func testError() {
+        XCTAssertNil(MIDI2.Int32(Int64(Swift.Int32.max) + 1))
+        XCTAssertThrowsError(try MIDI2.Int32(validating: Int64(Swift.Int32.max) + 1))
+
+        XCTAssertNil(MIDI2.Int32(Int64(Swift.Int32.min) - 1))
+        XCTAssertThrowsError(try MIDI2.Int32(validating: Int64(Swift.Int32.min) - 1))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = Int64.random(in: Int64(Swift.Int32.min)...Int64(Swift.Int32.max))
+            let int = try MIDI2.Int32(validating: raw)
+            XCTAssertEqual(int.rawValue, Swift.Int32(raw))
+        }
+
+        for _ in 0..<1_000 {
+            let raw = Int64.random(in: (Int64(Swift.Int32.max) + 1)...(Int64(Swift.Int32.max) + 1_000))
+            XCTAssertNil(MIDI2.Int32(raw))
+            XCTAssertThrowsError(try MIDI2.Int32(validating: raw))
+        }
+
+        for _ in 0..<1_000 {
+            let raw = Int64.random(in: (Int64(Swift.Int32.min) - 1_000)...(Int64(Swift.Int32.min) - 1))
+            XCTAssertNil(MIDI2.Int32(raw))
+            XCTAssertThrowsError(try MIDI2.Int32(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/Uint16Tests.swift
+++ b/Tests/MIDI2Tests/Uint16Tests.swift
@@ -2,7 +2,28 @@ import XCTest
 @testable import MIDI2
 
 final class Uint16Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Uint16
+    func testRoundTrip() throws {
+        let value: UInt32 = 0x1234
+        let uint = try XCTUnwrap(Uint16(value))
+        XCTAssertEqual(uint.rawValue, 0x1234)
+    }
+
+    func testError() {
+        XCTAssertNil(Uint16(0x1_0000))
+        XCTAssertThrowsError(try Uint16(validating: 0x1_0000))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt32.random(in: 0...0xFFFF)
+            let uint = try Uint16(validating: raw)
+            XCTAssertEqual(uint.rawValue, UInt16(raw))
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt32.random(in: 0x1_0000...UInt32.max)
+            XCTAssertNil(Uint16(raw))
+            XCTAssertThrowsError(try Uint16(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/Uint21Tests.swift
+++ b/Tests/MIDI2Tests/Uint21Tests.swift
@@ -2,7 +2,28 @@ import XCTest
 @testable import MIDI2
 
 final class Uint21Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Uint21
+    func testRoundTrip() throws {
+        let value: UInt32 = 0x1A_BCDE
+        let uint = try XCTUnwrap(Uint21(value))
+        XCTAssertEqual(uint.rawValue, value)
+    }
+
+    func testError() {
+        XCTAssertNil(Uint21(0x20_0000))
+        XCTAssertThrowsError(try Uint21(validating: 0x20_0000))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt32.random(in: 0...0x1F_FFFF)
+            let uint = try Uint21(validating: raw)
+            XCTAssertEqual(uint.rawValue, raw)
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt32.random(in: 0x20_0000...UInt32.max)
+            XCTAssertNil(Uint21(raw))
+            XCTAssertThrowsError(try Uint21(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/Uint28Tests.swift
+++ b/Tests/MIDI2Tests/Uint28Tests.swift
@@ -2,7 +2,28 @@ import XCTest
 @testable import MIDI2
 
 final class Uint28Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Uint28
+    func testRoundTrip() throws {
+        let value: UInt32 = 0x0ABC_DEF
+        let uint = try XCTUnwrap(Uint28(value))
+        XCTAssertEqual(uint.rawValue, value)
+    }
+
+    func testError() {
+        XCTAssertNil(Uint28(0x1_0000_000))
+        XCTAssertThrowsError(try Uint28(validating: 0x1_0000_000))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt32.random(in: 0...0x0FFF_FFFF)
+            let uint = try Uint28(validating: raw)
+            XCTAssertEqual(uint.rawValue, raw)
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt32.random(in: 0x1_0000_000...UInt32.max)
+            XCTAssertNil(Uint28(raw))
+            XCTAssertThrowsError(try Uint28(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/Uint32Tests.swift
+++ b/Tests/MIDI2Tests/Uint32Tests.swift
@@ -2,7 +2,28 @@ import XCTest
 @testable import MIDI2
 
 final class Uint32Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Uint32
+    func testRoundTrip() throws {
+        let value: UInt64 = 0xDEAD_BEEF
+        let uint = try XCTUnwrap(Uint32(value))
+        XCTAssertEqual(uint.rawValue, 0xDEAD_BEEF)
+    }
+
+    func testError() {
+        XCTAssertNil(Uint32(0x1_0000_0000))
+        XCTAssertThrowsError(try Uint32(validating: 0x1_0000_0000))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt64.random(in: 0...0xFFFF_FFFF)
+            let uint = try Uint32(validating: raw)
+            XCTAssertEqual(uint.rawValue, UInt32(raw))
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt64.random(in: 0x1_0000_0000...UInt64.max)
+            XCTAssertNil(Uint32(raw))
+            XCTAssertThrowsError(try Uint32(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/Uint8Tests.swift
+++ b/Tests/MIDI2Tests/Uint8Tests.swift
@@ -2,7 +2,28 @@ import XCTest
 @testable import MIDI2
 
 final class Uint8Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Uint8
+    func testRoundTrip() throws {
+        let value: UInt16 = 0xAB
+        let uint = try XCTUnwrap(Uint8(value))
+        XCTAssertEqual(uint.rawValue, 0xAB)
+    }
+
+    func testError() {
+        XCTAssertNil(Uint8(0x100))
+        XCTAssertThrowsError(try Uint8(validating: 0x100))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt16.random(in: 0...0xFF)
+            let uint = try Uint8(validating: raw)
+            XCTAssertEqual(uint.rawValue, UInt8(raw))
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt16.random(in: 0x100...UInt16.max)
+            XCTAssertNil(Uint8(raw))
+            XCTAssertThrowsError(try Uint8(validating: raw))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add range-checked wrappers for 8-, 16-, 21-, 28-, and 32-bit unsigned integers
- implement ByteArray, Group, and Int32 with validation and error reporting
- add round-trip, error, and fuzz tests for new types

## Testing
- `swift test --filter 'Uint8Tests|Uint16Tests|Uint21Tests|Uint28Tests|Uint32Tests|ByteArrayTests|GroupTests|Int32Tests'`


------
https://chatgpt.com/codex/tasks/task_b_689ca9f4080c83339bc0b4d70c287fde