### PR TITLE
Add UMP header bitfield accessors and packet composition tests

### DIFF
--- a/Sources/MIDI2/Ump128.swift
+++ b/Sources/MIDI2/Ump128.swift
@@ -15,6 +15,14 @@ public struct Ump128: UniversalPacket {
         self.word3 = word3
     }
 
+    /// Creates a packet from a 128-bit header and three payload words.
+    public init(header: UmpHeader128, word1: UInt32, word2: UInt32, word3: UInt32) {
+        self.word0 = header.word
+        self.word1 = word1
+        self.word2 = word2
+        self.word3 = word3
+    }
+
     /// Creates a packet from an array of words. Fails if count is not 4.
     public init?(words: [UInt32]) {
         guard words.count == Self.wordCount else { return nil }
@@ -26,6 +34,9 @@ public struct Ump128: UniversalPacket {
 
     /// The raw words composing the packet.
     public var words: [UInt32] { [word0, word1, word2, word3] }
+
+    /// Header view of the packet.
+    public var header: UmpHeader128 { UmpHeader128(word: word0)! }
 }
 
 public extension Ump128 {

--- a/Sources/MIDI2/Ump96.swift
+++ b/Sources/MIDI2/Ump96.swift
@@ -13,6 +13,13 @@ public struct Ump96: UniversalPacket {
         self.word2 = word2
     }
 
+    /// Creates a packet from a 32-bit header and two payload words.
+    public init(header: UmpHeader32, word1: UInt32, word2: UInt32) {
+        self.word0 = header.word
+        self.word1 = word1
+        self.word2 = word2
+    }
+
     /// Creates a packet from an array of words. Fails if count is not 3.
     public init?(words: [UInt32]) {
         guard words.count == Self.wordCount else { return nil }
@@ -23,6 +30,9 @@ public struct Ump96: UniversalPacket {
 
     /// The raw words composing the packet.
     public var words: [UInt32] { [word0, word1, word2] }
+
+    /// Header view of the packet.
+    public var header: UmpHeader32 { UmpHeader32(word: word0)! }
 }
 
 public extension Ump96 {

--- a/Sources/MIDI2/UmpHeader128.swift
+++ b/Sources/MIDI2/UmpHeader128.swift
@@ -1,3 +1,59 @@
-/// 128-bit UMP header for Data (SysEx8/MDS) and Flex Data.
-public struct UmpHeader128 {
+/// 128-bit UMP header for Data (SysEx8/MDS) and Flex Data messages.
+///
+/// The first word encodes the message type (``0x5`` for SysEx8 or ``0xD`` for
+/// Flex Data), an optional group, an 8-bit status field and two data bytes that
+/// commonly represent byte counts.
+public struct UmpHeader128: Equatable {
+    /// Raw 32-bit word representing the header.
+    public let word: UInt32
+
+    /// Creates a header from a raw word.  Fails if the message type is not
+    /// ``0x5`` or ``0xD``.
+    public init?(word: UInt32) {
+        let mt = UInt8((word >> 28) & 0xF)
+        guard mt == 0x5 || mt == 0xD else { return nil }
+        self.word = word
+    }
+
+    /// Creates a header from individual fields.
+    public init?(
+        messageType: UInt8,
+        group: Uint4,
+        status: UInt8,
+        byte3: UInt8,
+        byte4: UInt8
+    ) {
+        guard messageType == 0x5 || messageType == 0xD else { return nil }
+
+        let word =
+            (UInt32(messageType) << 28) |
+            (UInt32(group.rawValue) << 24) |
+            (UInt32(status) << 16) |
+            (UInt32(byte3) << 8) |
+            UInt32(byte4)
+
+        self.word = word
+    }
+
+    /// Message type nibble (``0x5`` or ``0xD``).
+    public var messageType: UInt8 { UInt8((word >> 28) & 0xF) }
+
+    /// Group nibble.
+    public var group: Uint4 { Uint4(UInt8((word >> 24) & 0xF))! }
+
+    /// Status byte (bits 23-16).
+    public var status: UInt8 { UInt8((word >> 16) & 0xFF) }
+
+    /// Byte 3 (bits 15-8) – often the MSB of a byte count.
+    public var byte3: UInt8 { UInt8((word >> 8) & 0xFF) }
+
+    /// Byte 4 (bits 7-0) – often the LSB of a byte count.
+    public var byte4: UInt8 { UInt8(word & 0xFF) }
+
+    /// Number of following 32-bit words in the packet.
+    public var dataWordCount: Int { 3 }
+
+    /// Total number of data bytes in the packet following the status byte.
+    public var dataByteCount: Int { 14 }
 }
+

--- a/Sources/MIDI2/UmpHeader32.swift
+++ b/Sources/MIDI2/UmpHeader32.swift
@@ -1,3 +1,85 @@
-/// Common 32-bit UMP header (messageType + optional group).
-public struct UmpHeader32 {
+/// Common 32-bit UMP header (messageType + group + status + two data bytes).
+///
+/// The first 32-bit word of many UMP packet types share this layout.  The
+/// leading nibble is the message type, followed by a 4-bit group.  The next
+/// byte is the status field and the final two bytes are typically payload
+/// data or counts depending on the message type.
+public struct UmpHeader32: Equatable {
+    /// Raw 32-bit word representing the header.
+    public let word: UInt32
+
+    /// Creates a header from a raw 32-bit word.  Fails if the message type is
+    /// not one of the valid 32-bit UMP types.
+    public init?(word: UInt32) {
+        let mt = UInt8((word >> 28) & 0xF)
+        // Valid message types for 32-bit packets as defined by the MIDI 2.0
+        // specification (Utility, System, MIDI 1.0, Data64, or Flex Data).
+        let valid: Set<UInt8> = [0, 1, 2, 3, 15]
+        guard valid.contains(mt) else { return nil }
+        self.word = word
+    }
+
+    /// Creates a header from individual fields.
+    public init?(
+        messageType: UInt8,
+        group: Uint4,
+        status: UInt8,
+        byte1: UInt8,
+        byte2: UInt8
+    ) {
+        let valid: Set<UInt8> = [0, 1, 2, 3, 15]
+        guard valid.contains(messageType) else { return nil }
+
+        let word =
+            (UInt32(messageType) << 28) |
+            (UInt32(group.rawValue) << 24) |
+            (UInt32(status) << 16) |
+            (UInt32(byte1) << 8) |
+            UInt32(byte2)
+
+        self.word = word
+    }
+
+    /// The 4-bit message type field (bits 31-28).
+    public var messageType: UInt8 { UInt8((word >> 28) & 0xF) }
+
+    /// The 4-bit group field (bits 27-24).
+    public var group: Uint4 { Uint4(UInt8((word >> 24) & 0xF))! }
+
+    /// The 8-bit status field (bits 23-16).
+    public var status: UInt8 { UInt8((word >> 16) & 0xFF) }
+
+    /// Byte 3 of the packet (bits 15-8).
+    public var byte1: UInt8 { UInt8((word >> 8) & 0xFF) }
+
+    /// Byte 4 of the packet (bits 7-0).
+    public var byte2: UInt8 { UInt8(word & 0xFF) }
+
+    /// The lower 16 bits interpreted as a single value.
+    public var data: UInt16 { UInt16(byte1) << 8 | UInt16(byte2) }
+
+    /// Number of data bytes following the status byte.  For MIDI 1.0 channel
+    /// voice messages this depends on the status nibble; for most other
+    /// messages the value is fixed by the specification.
+    public var dataByteCount: Int {
+        let status = self.status
+        let statusNibble = status >> 4
+
+        switch statusNibble {
+        case 0xC, 0xD:
+            return 1
+        case 0xF:
+            switch status & 0xF {
+            case 0x1, 0x3:
+                return 1
+            case 0x2:
+                return 2
+            default:
+                return 0
+            }
+        default:
+            return 2
+        }
+    }
 }
+

--- a/Sources/MIDI2/UmpHeader64.swift
+++ b/Sources/MIDI2/UmpHeader64.swift
@@ -1,3 +1,63 @@
-/// 64-bit UMP header for MIDI 2.0 Channel Voice.
-public struct UmpHeader64 {
+/// 64-bit UMP header for MIDI 2.0 Channel Voice messages.
+///
+/// The first word encodes message type ``0x4``, a group nibble, status nibble,
+/// channel, and two data bytes.  The remaining word contains additional payload
+/// data.
+public struct UmpHeader64: Equatable {
+    /// Raw 32-bit word representing the header.
+    public let word: UInt32
+
+    /// Creates a header from a raw word.  Fails if the message type nibble is
+    /// not ``0x4``.
+    public init?(word: UInt32) {
+        guard UInt8((word >> 28) & 0xF) == 0x4 else { return nil }
+        self.word = word
+    }
+
+    /// Creates a header from individual fields.
+    public init?(
+        group: Uint4,
+        status: Uint4,
+        channel: Uint4,
+        byte3: UInt8,
+        byte4: UInt8
+    ) {
+        // Channel voice status nibbles range 8-F.
+        guard status.rawValue >= 0x8 else { return nil }
+
+        let word =
+            (UInt32(0x4) << 28) |
+            (UInt32(group.rawValue) << 24) |
+            (UInt32(status.rawValue) << 20) |
+            (UInt32(channel.rawValue) << 16) |
+            (UInt32(byte3) << 8) |
+            UInt32(byte4)
+
+        self.word = word
+    }
+
+    /// Message type nibble (always ``0x4``).
+    public var messageType: UInt8 { UInt8((word >> 28) & 0xF) }
+
+    /// Group nibble.
+    public var group: Uint4 { Uint4(UInt8((word >> 24) & 0xF))! }
+
+    /// Status nibble (bits 23-20).
+    public var status: Uint4 { Uint4(UInt8((word >> 20) & 0xF))! }
+
+    /// Channel nibble (bits 19-16).
+    public var channel: Uint4 { Uint4(UInt8((word >> 16) & 0xF))! }
+
+    /// Byte 3 (bits 15-8).
+    public var byte3: UInt8 { UInt8((word >> 8) & 0xFF) }
+
+    /// Byte 4 (bits 7-0).
+    public var byte4: UInt8 { UInt8(word & 0xFF) }
+
+    /// Number of following 32-bit words in the packet.
+    public var dataWordCount: Int { 1 }
+
+    /// Total number of data bytes in the packet following the status nibble.
+    public var dataByteCount: Int { 6 }
 }
+

--- a/Sources/MIDI2/UmpPacket32.swift
+++ b/Sources/MIDI2/UmpPacket32.swift
@@ -2,14 +2,26 @@
 public struct UmpPacket32: Equatable {
     public let word: UInt32
 
+    /// Creates a packet from a raw 32-bit word.
     public init(word: UInt32) {
         self.word = word
     }
 
+    /// Creates a packet from a header.
+    public init(header: UmpHeader32) {
+        self.word = header.word
+    }
+
+    /// Convenience initializer using individual fields.
     public init(mt: UInt8, group: Uint4, status: UInt8, data1: UInt8, data2: UInt8) {
-        let byte0 = UInt32(mt << 4 | group.rawValue)
-        let word = (byte0 << 24) | (UInt32(status) << 16) | (UInt32(data1) << 8) | UInt32(data2)
-        self.word = word
+        let header = UmpHeader32(
+            messageType: mt,
+            group: group,
+            status: status,
+            byte1: data1,
+            byte2: data2
+        )!
+        self.init(header: header)
     }
 
     public init?(midi1Bytes bytes: [UInt8], group: Uint4) {
@@ -19,6 +31,9 @@ public struct UmpPacket32: Equatable {
         let data2: UInt8 = bytes.count > 2 ? bytes[2] : 0
         self.init(mt: 0x2, group: group, status: status, data1: data1, data2: data2)
     }
+
+    /// Header view of the packet.
+    public var header: UmpHeader32 { UmpHeader32(word: word)! }
 
     public func midi1Bytes() -> [UInt8]? {
         let mt = UInt8((word >> 28) & 0xF)

--- a/Sources/MIDI2/UmpPacket64.swift
+++ b/Sources/MIDI2/UmpPacket64.swift
@@ -14,6 +14,12 @@ public struct UmpPacket64: Equatable, UniversalPacket {
         self.word1 = word1
     }
 
+    /// Creates a packet from a header and payload word.
+    public init(header: UmpHeader64, word1: UInt32) {
+        self.word0 = header.word
+        self.word1 = word1
+    }
+
     /// Creates a packet from an array of two 32-bit words.
     public init?(words: [UInt32]) {
         guard words.count == 2 else { return nil }
@@ -22,4 +28,7 @@ public struct UmpPacket64: Equatable, UniversalPacket {
 
     /// Returns the raw 32-bit words making up this packet.
     public var words: [UInt32] { [word0, word1] }
+
+    /// Header view of the packet.
+    public var header: UmpHeader64 { UmpHeader64(word: word0)! }
 }

--- a/Tests/MIDI2Tests/UmpHeader128Tests.swift
+++ b/Tests/MIDI2Tests/UmpHeader128Tests.swift
@@ -2,7 +2,29 @@ import XCTest
 @testable import MIDI2
 
 final class UmpHeader128Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UmpHeader128
+    func testPackingUnpacking() throws {
+        let group = try XCTUnwrap(Uint4(0x1))
+        let header = try XCTUnwrap(
+            UmpHeader128(messageType: 0x5, group: group, status: 0x7F, byte3: 0x01, byte4: 0x02)
+        )
+
+        XCTAssertEqual(header.messageType, 0x5)
+        XCTAssertEqual(header.group, group)
+        XCTAssertEqual(header.status, 0x7F)
+        XCTAssertEqual(header.byte3, 0x01)
+        XCTAssertEqual(header.byte4, 0x02)
+        XCTAssertEqual(header.dataWordCount, 3)
+        XCTAssertEqual(header.dataByteCount, 14)
+
+        let packet = Ump128(header: header, word1: 0x11111111, word2: 0x22222222, word3: 0x33333333)
+        XCTAssertEqual(packet.header, header)
+    }
+
+    func testInvalidMessageType() throws {
+        let group = try XCTUnwrap(Uint4(0x1))
+        XCTAssertNil(UmpHeader128(messageType: 0x7, group: group, status: 0, byte3: 0, byte4: 0))
+
+        let badWord: UInt32 = 0x7000_0000
+        XCTAssertNil(UmpHeader128(word: badWord))
     }
 }

--- a/Tests/MIDI2Tests/UmpHeader32Tests.swift
+++ b/Tests/MIDI2Tests/UmpHeader32Tests.swift
@@ -2,7 +2,35 @@ import XCTest
 @testable import MIDI2
 
 final class UmpHeader32Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UmpHeader32
+    /// Verify packing and unpacking of fields as well as composition with packet types.
+    func testPackingUnpacking() throws {
+        let group = try XCTUnwrap(Uint4(0x2))
+        let header = try XCTUnwrap(
+            UmpHeader32(messageType: 0x2, group: group, status: 0x90, byte1: 0x12, byte2: 0x34)
+        )
+
+        XCTAssertEqual(header.messageType, 0x2)
+        XCTAssertEqual(header.group, group)
+        XCTAssertEqual(header.status, 0x90)
+        XCTAssertEqual(header.byte1, 0x12)
+        XCTAssertEqual(header.byte2, 0x34)
+        XCTAssertEqual(header.dataByteCount, 2)
+
+        // Compose with UmpPacket32
+        let packet32 = UmpPacket32(header: header)
+        XCTAssertEqual(packet32.header, header)
+
+        // Compose with Ump96
+        let packet96 = Ump96(header: header, word1: 0x01020304, word2: 0x05060708)
+        XCTAssertEqual(packet96.header, header)
+    }
+
+    /// Ensure invalid message types are rejected.
+    func testInvalidMessageType() throws {
+        let group = try XCTUnwrap(Uint4(0x1))
+        XCTAssertNil(UmpHeader32(messageType: 0x6, group: group, status: 0x00, byte1: 0x00, byte2: 0x00))
+
+        let word: UInt32 = 0x6000_0000
+        XCTAssertNil(UmpHeader32(word: word))
     }
 }

--- a/Tests/MIDI2Tests/UmpHeader64Tests.swift
+++ b/Tests/MIDI2Tests/UmpHeader64Tests.swift
@@ -2,7 +2,37 @@ import XCTest
 @testable import MIDI2
 
 final class UmpHeader64Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UmpHeader64
+    /// Verify packing/unpacking and packet composition.
+    func testPackingUnpacking() throws {
+        let group = try XCTUnwrap(Uint4(0x1))
+        let status = try XCTUnwrap(Uint4(0x9))
+        let channel = try XCTUnwrap(Uint4(0x3))
+
+        let header = try XCTUnwrap(
+            UmpHeader64(group: group, status: status, channel: channel, byte3: 0x12, byte4: 0x34)
+        )
+
+        XCTAssertEqual(header.messageType, 0x4)
+        XCTAssertEqual(header.group, group)
+        XCTAssertEqual(header.status, status)
+        XCTAssertEqual(header.channel, channel)
+        XCTAssertEqual(header.byte3, 0x12)
+        XCTAssertEqual(header.byte4, 0x34)
+        XCTAssertEqual(header.dataWordCount, 1)
+        XCTAssertEqual(header.dataByteCount, 6)
+
+        let packet = UmpPacket64(header: header, word1: 0x55667788)
+        XCTAssertEqual(packet.header, header)
+    }
+
+    /// Ensure invalid status nibbles and message types are detected.
+    func testInvalidFields() throws {
+        let group = try XCTUnwrap(Uint4(0x1))
+        let channel = try XCTUnwrap(Uint4(0x3))
+        let badStatus = try XCTUnwrap(Uint4(0x7)) // < 8
+        XCTAssertNil(UmpHeader64(group: group, status: badStatus, channel: channel, byte3: 0, byte4: 0))
+
+        let badWord: UInt32 = 0x5000_0000
+        XCTAssertNil(UmpHeader64(word: badWord))
     }
 }


### PR DESCRIPTION
## Summary
- expose message type, group, status and data-byte counts for 32-, 64- and 128-bit UMP headers
- integrate headers with UmpPacket32/64/96/128 for easier packet assembly and parsing
- add tests covering packing/unpacking and invalid field detection

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689cb0d26b5c8333ae797cfb32b61db3