### PR TITLE
Add basic message bodies and UMP round‑trip tests

### DIFF
--- a/Sources/MIDI2/DataMessageBody.swift
+++ b/Sources/MIDI2/DataMessageBody.swift
@@ -1,3 +1,42 @@
-/// Body payload for UMP Data Messages.
-public struct DataMessageBody {
+import Foundation
+
+/// Body payload for UMP Data Messages (message type ``0x5``).
+///
+/// This implementation currently supports SysEx8 transfers.  Mixed Data Set
+/// transfers are modelled by the `mds` case but are not yet encoded.
+public enum DataMessageBody: Equatable {
+    /// SysEx8 payload consisting of manufacturer ID and data bytes.
+    case sysex8(manufacturerID: [UInt8], data: [UInt8])
+    /// Mixed Data Set payload (not fully implemented).
+    case mds
+
+    /// Kind of data message.
+    public var kind: DataMessageKind {
+        switch self {
+        case .sysex8: return .sysex8
+        case .mds: return .mds
+        }
+    }
+
+    /// Encodes the body into an array of ``UmpPacket128`` packets using the
+    /// supplied group.
+    public func umpPackets(group: Uint4) throws -> [UmpPacket128] {
+        switch self {
+        case let .sysex8(mfr, data):
+            let packets = try SysEx8.fragment(manufacturerID: mfr, payload: data, group: group.rawValue)
+            return packets.compactMap { UmpPacket128(rawBytes: $0) }
+        case .mds:
+            // Encoding for MDS is not implemented.
+            return []
+        }
+    }
+
+    /// Decodes a SysEx8 body from an array of ``UmpPacket128`` packets.
+    /// Returns `nil` if the packets do not form a valid SysEx8 transfer.
+    public init?(sysex8Packets packets: [UmpPacket128]) {
+        let raw = packets.map { $0.rawBytes }
+        guard let (mfr, payload) = try? SysEx8.reassemble(raw) else { return nil }
+        self = .sysex8(manufacturerID: mfr, data: payload)
+    }
 }
+

--- a/Sources/MIDI2/DataMessageKind.swift
+++ b/Sources/MIDI2/DataMessageKind.swift
@@ -1,3 +1,9 @@
-/// Enumeration of UMP data message kinds.
-public struct DataMessageKind {
+/// Enumeration of UMP data message kinds used with message type ``0x5``.
+///
+/// - `sysex8`: 8‑bit clean System Exclusive data.
+/// - `mds`: Mixed Data Set transfer.
+public enum DataMessageKind: String, Equatable {
+    case sysex8
+    case mds
 }
+

--- a/Sources/MIDI2/StreamBody.swift
+++ b/Sources/MIDI2/StreamBody.swift
@@ -1,3 +1,59 @@
-/// Endpoint discovery, protocol selection, and FB info.
-public struct StreamBody {
+/// Body for UMP message type ``0xF`` Stream packets.
+///
+/// Stream packets are used during endpoint discovery and configuration.  Each
+/// packet carries an opcode followed by two data bytes whose meaning depends on
+/// the opcode.
+public struct StreamBody: Equatable {
+    /// Stream message opcode.
+    public var opcode: StreamOpcode
+    /// First data byte following the opcode.
+    public var data1: UInt8
+    /// Second data byte following the opcode.
+    public var data2: UInt8
+
+    /// Creates a new body.
+    public init(opcode: StreamOpcode, data1: UInt8 = 0, data2: UInt8 = 0) {
+        self.opcode = opcode
+        self.data1 = data1
+        self.data2 = data2
+    }
+
+    /// Encodes the body into a 32‑bit UMP packet using the supplied group.
+    public func ump(group: Uint4) -> UmpPacket32 {
+        let byte0 = UInt32(0xF << 4 | group.rawValue)
+        let word = (byte0 << 24) |
+                   (UInt32(opcode.rawValue) << 16) |
+                   (UInt32(data1) << 8) |
+                   UInt32(data2)
+        return UmpPacket32(word: word)
+    }
+
+    /// Decodes a body from a 32‑bit UMP packet.
+    public init?(ump: UmpPacket32) {
+        let word = ump.word
+        let mt = UInt8((word >> 28) & 0xF)
+        guard mt == 0xF else { return nil }
+        let status = UInt8((word >> 16) & 0xFF)
+        guard let op = StreamOpcode(rawValue: status) else { return nil }
+        let data1 = UInt8((word >> 8) & 0xFF)
+        let data2 = UInt8(word & 0xFF)
+        self.init(opcode: op, data1: data1, data2: data2)
+    }
+
+    /// Failable initialiser that throws ``MIDIError`` on malformed packets.
+    public init(parsingUMP ump: UmpPacket32) throws {
+        let word = ump.word
+        let mt = UInt8((word >> 28) & 0xF)
+        guard mt == 0xF else {
+            throw MIDIError.malformedPacket("expected mt 0xF but got \(mt)")
+        }
+        let status = UInt8((word >> 16) & 0xFF)
+        guard let op = StreamOpcode(rawValue: status) else {
+            throw MIDIError.malformedPacket("invalid stream opcode 0x\(String(status, radix: 16))")
+        }
+        let data1 = UInt8((word >> 8) & 0xFF)
+        let data2 = UInt8(word & 0xFF)
+        self.init(opcode: op, data1: data1, data2: data2)
+    }
 }
+

--- a/Sources/MIDI2/StreamOpcode.swift
+++ b/Sources/MIDI2/StreamOpcode.swift
@@ -1,3 +1,13 @@
-/// Opcode values for MIDI 2.0 Stream messages.
-public struct StreamOpcode {
+/// Opcode values for MIDI 2.0 Stream messages (message type ``0xF``).
+///
+/// The standard currently defines three opcodes used to manage endpoints and
+/// function blocks during connection setup.
+public enum StreamOpcode: UInt8, Equatable {
+    /// Endpoint discovery message.
+    case endpointDiscovery      = 0x00
+    /// Stream configuration (request or notification).
+    case streamConfiguration    = 0x01
+    /// Function block discovery or information message.
+    case functionBlock          = 0x02
 }
+

--- a/Sources/MIDI2/SysEx7Body.swift
+++ b/Sources/MIDI2/SysEx7Body.swift
@@ -1,3 +1,70 @@
-/// 7-bit clean stream framed in 32-bit UMP words (up to 6 bytes per word).
-public struct SysEx7Body {
+/// Body of a single SysEx7 UMP packet.
+///
+/// The packet is represented as the status nibble, the byte count and up to six
+/// bytes of payload data.  Encoding and decoding operate on ``UmpPacket64``
+/// values as SysEx7 packets are 64 bits wide.
+public struct SysEx7Body: Equatable {
+    /// Status nibble (0 = complete, 1 = start, 2 = continue, 3 = end).
+    public enum Status: UInt8, Equatable {
+        case complete = 0x0
+        case start    = 0x1
+        case `continue` = 0x2
+        case end      = 0x3
+    }
+
+    /// Status of the packet.
+    public var status: Status
+    /// Payload data (0–6 bytes).
+    public var data: [UInt8]
+
+    /// Creates a new body.
+    public init(status: Status, data: [UInt8]) {
+        precondition(data.count <= 6)
+        self.status = status
+        self.data = data
+    }
+
+    /// Encodes the body into a ``UmpPacket64`` using the supplied group.
+    public func ump(group: Uint4) -> UmpPacket64 {
+        var bytes: [UInt8] = [0x30 | group.rawValue,
+                              (status.rawValue << 4) | UInt8(data.count)]
+        bytes.append(contentsOf: data)
+        if data.count < 6 {
+            bytes.append(contentsOf: Array(repeating: 0, count: 6 - data.count))
+        }
+        return UmpPacket64(rawBytes: bytes)!
+    }
+
+    /// Decodes a body from a ``UmpPacket64``.
+    public init?(ump: UmpPacket64) {
+        let bytes = ump.rawBytes
+        let mt = bytes[0] >> 4
+        guard mt == 0x3 else { return nil }
+        let statusNibble = bytes[1] >> 4
+        guard let status = Status(rawValue: statusNibble) else { return nil }
+        let count = Int(bytes[1] & 0x0F)
+        guard count <= 6 else { return nil }
+        let payload = Array(bytes[2..<(2 + count)])
+        self.init(status: status, data: payload)
+    }
+
+    /// Failable initialiser that throws ``MIDIError`` for malformed packets.
+    public init(parsingUMP ump: UmpPacket64) throws {
+        let bytes = ump.rawBytes
+        let mt = bytes[0] >> 4
+        guard mt == 0x3 else {
+            throw MIDIError.malformedPacket("expected mt 0x3 but got \(mt)")
+        }
+        let statusNibble = bytes[1] >> 4
+        guard let status = Status(rawValue: statusNibble) else {
+            throw MIDIError.malformedPacket("invalid SysEx7 status 0x\(String(statusNibble, radix: 16))")
+        }
+        let count = Int(bytes[1] & 0x0F)
+        guard count <= 6 else {
+            throw MIDIError.malformedPacket("invalid byte count \(count)")
+        }
+        let payload = Array(bytes[2..<(2 + count)])
+        self.init(status: status, data: payload)
+    }
 }
+

--- a/Sources/MIDI2/SystemCommonRealtimeBody.swift
+++ b/Sources/MIDI2/SystemCommonRealtimeBody.swift
@@ -1,3 +1,59 @@
-/// UMP 0x1 System Common & Real-Time.
-public struct SystemCommonRealtimeBody {
+/// Body for UMP message type ``0x1`` carrying System Common or Real‑Time data.
+///
+/// The message header provides the group nibble while this body models the
+/// status byte and the two following data bytes.
+public struct SystemCommonRealtimeBody: Equatable {
+    /// MIDI system status byte.
+    public var status: SystemStatus
+    /// First data byte (may be unused for some statuses).
+    public var data1: UInt8
+    /// Second data byte (may be unused for some statuses).
+    public var data2: UInt8
+
+    /// Creates a new body.
+    public init(status: SystemStatus, data1: UInt8 = 0, data2: UInt8 = 0) {
+        self.status = status
+        self.data1 = data1
+        self.data2 = data2
+    }
+
+    /// Encodes the body into a 32‑bit UMP packet using the supplied group.
+    public func ump(group: Uint4) -> UmpPacket32 {
+        let byte0 = UInt32(0x1 << 4 | group.rawValue)
+        let word = (byte0 << 24) |
+                   (UInt32(status.rawValue) << 16) |
+                   (UInt32(data1) << 8) |
+                   UInt32(data2)
+        return UmpPacket32(word: word)
+    }
+
+    /// Decodes a body from a 32‑bit UMP packet.
+    public init?(ump: UmpPacket32) {
+        let word = ump.word
+        let mt = UInt8((word >> 28) & 0xF)
+        guard mt == 0x1 else { return nil }
+        let statusByte = UInt8((word >> 16) & 0xFF)
+        guard let status = SystemStatus(rawValue: statusByte) else { return nil }
+        let data1 = UInt8((word >> 8) & 0xFF)
+        let data2 = UInt8(word & 0xFF)
+        self.init(status: status, data1: data1, data2: data2)
+    }
+
+    /// Failable initialiser that performs validation and throws `MIDIError` on
+    /// malformed packets.
+    public init(parsingUMP ump: UmpPacket32) throws {
+        let word = ump.word
+        let mt = UInt8((word >> 28) & 0xF)
+        guard mt == 0x1 else {
+            throw MIDIError.malformedPacket("expected mt 0x1 but got \(mt)")
+        }
+        let statusByte = UInt8((word >> 16) & 0xFF)
+        guard let status = SystemStatus(rawValue: statusByte) else {
+            throw MIDIError.malformedPacket("invalid system status 0x\(String(statusByte, radix: 16))")
+        }
+        let data1 = UInt8((word >> 8) & 0xFF)
+        let data2 = UInt8(word & 0xFF)
+        self.init(status: status, data1: data1, data2: data2)
+    }
 }
+

--- a/Sources/MIDI2/SystemStatus.swift
+++ b/Sources/MIDI2/SystemStatus.swift
@@ -1,3 +1,22 @@
-/// MIDI System Common/Real-Time per UMP.
-public struct SystemStatus {
+/// All status bytes that are considered valid for UMP System Common and
+/// System Real‑Time messages.
+///
+/// The values correspond directly to the 8‑bit status byte found in the
+/// second byte of a message type ``0x1`` UMP packet.  Both System Common and
+/// System Real‑Time messages share this enumeration.
+public enum SystemStatus: UInt8, Equatable {
+    // System Common
+    case mtcQuarterFrame     = 0xF1
+    case songPositionPointer = 0xF2
+    case songSelect          = 0xF3
+    case tuneRequest         = 0xF6
+
+    // System Real‑Time
+    case timingClock  = 0xF8
+    case start        = 0xFA
+    case `continue`   = 0xFB
+    case stop         = 0xFC
+    case activeSensing = 0xFE
+    case systemReset   = 0xFF
 }
+

--- a/Sources/MIDI2/UmpPacket128.swift
+++ b/Sources/MIDI2/UmpPacket128.swift
@@ -1,3 +1,32 @@
 /// 128-bit Universal MIDI Packet consisting of four 32-bit words.
-public struct UmpPacket128 {
+public struct UmpPacket128: Equatable, UniversalPacket {
+    /// The four 32-bit words of the packet.
+    public let word0: UInt32
+    public let word1: UInt32
+    public let word2: UInt32
+    public let word3: UInt32
+
+    /// Number of 32-bit words.
+    public static let wordCount: Int = 4
+
+    /// Creates a packet from four words.
+    public init(word0: UInt32, word1: UInt32, word2: UInt32, word3: UInt32) {
+        self.word0 = word0
+        self.word1 = word1
+        self.word2 = word2
+        self.word3 = word3
+    }
+
+    /// Creates a packet from an array of words.
+    public init?(words: [UInt32]) {
+        guard words.count == 4 else { return nil }
+        self.init(word0: words[0], word1: words[1], word2: words[2], word3: words[3])
+    }
+
+    /// Returns the words making up the packet.
+    public var words: [UInt32] { [word0, word1, word2, word3] }
+
+    /// Header view of the packet.
+    public var header: UmpHeader128 { UmpHeader128(word: word0)! }
 }
+

--- a/Sources/MIDI2/UtilityBody.swift
+++ b/Sources/MIDI2/UtilityBody.swift
@@ -1,3 +1,59 @@
-/// UMP Type 0x0 Utility messages (groupless).
-public struct UtilityBody {
+/// Body payload for UMP message type ``0x0`` Utility packets.
+///
+/// Utility packets are _groupless_ and contain a single opcode in the status
+/// byte followed by two data bytes that are interpreted according to the
+/// opcode.  The body therefore stores the opcode and the raw 16‑bit value.
+public struct UtilityBody: Equatable {
+    /// The opcode describing the utility message.
+    public var opcode: UtilityOpcode
+    /// Raw 16‑bit value carried in bytes 2 and 3 of the packet.
+    public var value: UInt16
+
+    /// Creates a new body with the supplied opcode and value.
+    public init(opcode: UtilityOpcode, value: UInt16 = 0) {
+        self.opcode = opcode
+        self.value = value
+    }
+
+    /// Encodes the body into a 32‑bit UMP packet.
+    public func ump() -> UmpPacket32 {
+        let byte0 = UInt32(0x0 << 4) // message type 0x0, groupless
+        let word = (byte0 << 24) | (UInt32(opcode.rawValue) << 16) | UInt32(value)
+        return UmpPacket32(word: word)
+    }
+
+    /// Decodes a body from a 32‑bit UMP packet.
+    /// Returns `nil` if the packet is not a Utility message.
+    public init?(ump: UmpPacket32) {
+        let word = ump.word
+        let byte0 = UInt8((word >> 24) & 0xFF)
+        let mt = byte0 >> 4
+        guard mt == 0x0 else { return nil }
+        guard byte0 & 0x0F == 0 else { return nil }
+        let status = UInt8((word >> 16) & 0xFF)
+        guard let op = UtilityOpcode(rawValue: status) else { return nil }
+        let value = UInt16(word & 0xFFFF)
+        self.init(opcode: op, value: value)
+    }
+
+    /// Failable initialiser that validates the packet and throws `MIDIError`
+    /// on malformed input.
+    public init(parsingUMP ump: UmpPacket32) throws {
+        let word = ump.word
+        let byte0 = UInt8((word >> 24) & 0xFF)
+        let mt = byte0 >> 4
+        guard mt == 0x0 else {
+            throw MIDIError.malformedPacket("expected mt 0x0 but got \(mt)")
+        }
+        guard byte0 & 0x0F == 0 else {
+            throw MIDIError.malformedPacket("utility messages must have group 0")
+        }
+        let status = UInt8((word >> 16) & 0xFF)
+        guard let op = UtilityOpcode(rawValue: status) else {
+            throw MIDIError.malformedPacket("unknown utility opcode 0x\(String(status, radix: 16))")
+        }
+        let value = UInt16(word & 0xFFFF)
+        self.init(opcode: op, value: value)
+    }
 }
+

--- a/Sources/MIDI2/UtilityOpcode.swift
+++ b/Sources/MIDI2/UtilityOpcode.swift
@@ -1,3 +1,15 @@
-/// 0=NOOP,1=JR Clock,2=JR Timestamp
-public struct UtilityOpcode {
+/// Opcode values for UMP Utility messages.
+///
+/// These opcodes occupy the status byte of a message type ``0x0`` packet and
+/// determine how the remaining 16 bits of the packet should be interpreted.
+/// The library only defines the three opcodes currently specified by the
+/// standard.
+public enum UtilityOpcode: UInt8, Equatable {
+    /// No operation.  Used for padding.
+    case noop        = 0x00
+    /// Jitter Reduction Clock – carries a 16-bit timestamp value.
+    case jrClock     = 0x01
+    /// Jitter Reduction Timestamp – carries a 16-bit timestamp value.
+    case jrTimestamp = 0x02
 }
+

--- a/Tests/MIDI2Tests/DataMessageBodyTests.swift
+++ b/Tests/MIDI2Tests/DataMessageBodyTests.swift
@@ -2,7 +2,10 @@ import XCTest
 @testable import MIDI2
 
 final class DataMessageBodyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test DataMessageBody
+    func testRoundTripSysEx8() throws {
+        let body = DataMessageBody.sysex8(manufacturerID: [0x7D], data: [0x01,0x02,0x03,0x04,0x05])
+        let packets = try body.umpPackets(group: Uint4(0x0)!)
+        let decoded = DataMessageBody(sysex8Packets: packets)
+        XCTAssertEqual(decoded, body)
     }
 }

--- a/Tests/MIDI2Tests/StreamBodyTests.swift
+++ b/Tests/MIDI2Tests/StreamBodyTests.swift
@@ -2,7 +2,12 @@ import XCTest
 @testable import MIDI2
 
 final class StreamBodyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test StreamBody
+    func testRoundTrip() throws {
+        let body = StreamBody(opcode: .endpointDiscovery, data1: 0x12, data2: 0x34)
+        let packet = body.ump(group: Uint4(0x2)!)
+        let decoded = StreamBody(ump: packet)
+        XCTAssertEqual(decoded, body)
+
+        XCTAssertNoThrow(try StreamBody(parsingUMP: packet))
     }
 }

--- a/Tests/MIDI2Tests/SysEx7BodyTests.swift
+++ b/Tests/MIDI2Tests/SysEx7BodyTests.swift
@@ -2,7 +2,12 @@ import XCTest
 @testable import MIDI2
 
 final class SysEx7BodyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test SysEx7Body
+    func testRoundTrip() throws {
+        let body = SysEx7Body(status: .start, data: [1,2,3])
+        let packet = body.ump(group: Uint4(0x1)!)
+        let decoded = SysEx7Body(ump: packet)
+        XCTAssertEqual(decoded, body)
+
+        XCTAssertNoThrow(try SysEx7Body(parsingUMP: packet))
     }
 }

--- a/Tests/MIDI2Tests/SystemCommonRealtimeBodyTests.swift
+++ b/Tests/MIDI2Tests/SystemCommonRealtimeBodyTests.swift
@@ -2,7 +2,12 @@ import XCTest
 @testable import MIDI2
 
 final class SystemCommonRealtimeBodyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test SystemCommonRealtimeBody
+    func testRoundTripSongSelect() throws {
+        let body = SystemCommonRealtimeBody(status: .songSelect, data1: 0x7F)
+        let packet = body.ump(group: Uint4(0x3)!)
+        let decoded = SystemCommonRealtimeBody(ump: packet)
+        XCTAssertEqual(decoded, body)
+
+        XCTAssertNoThrow(try SystemCommonRealtimeBody(parsingUMP: packet))
     }
 }

--- a/Tests/MIDI2Tests/UtilityBodyTests.swift
+++ b/Tests/MIDI2Tests/UtilityBodyTests.swift
@@ -2,7 +2,13 @@ import XCTest
 @testable import MIDI2
 
 final class UtilityBodyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UtilityBody
+    func testRoundTripJRClock() throws {
+        let body = UtilityBody(opcode: .jrClock, value: 0x1234)
+        let packet = body.ump()
+        let decoded = UtilityBody(ump: packet)
+        XCTAssertEqual(decoded, body)
+
+        // throwing variant
+        XCTAssertNoThrow(try UtilityBody(parsingUMP: packet))
     }
 }


### PR DESCRIPTION
## Summary
- implement opcode enums and body structs for Utility, Stream and System messages
- add SysEx7 and Data message bodies with simple UMP encode/decode helpers
- create round‑trip tests for new body types

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689cb34066a88333828e4ce018c4b12c