### PR TITLE
Implement SysEx7 packet and body utilities

### DIFF
--- a/Sources/MIDI2/SysEx7Body.swift
+++ b/Sources/MIDI2/SysEx7Body.swift
@@ -1,70 +1,51 @@
-/// Body of a single SysEx7 UMP packet.
-///
-/// The packet is represented as the status nibble, the byte count and up to six
-/// bytes of payload data.  Encoding and decoding operate on ``UmpPacket64``
-/// values as SysEx7 packets are 64 bits wide.
+/// Sequence of SysEx7 packets representing a complete SysEx7 message.
 public struct SysEx7Body: Equatable {
-    /// Status nibble (0 = complete, 1 = start, 2 = continue, 3 = end).
-    public enum Status: UInt8, Equatable {
-        case complete = 0x0
-        case start    = 0x1
-        case `continue` = 0x2
-        case end      = 0x3
+    /// Ordered packets forming the SysEx7 transfer.
+    public var packets: [SysEx7Packet]
+
+    /// Creates a body from already constructed packets.
+    public init(packets: [SysEx7Packet]) {
+        self.packets = packets
     }
 
-    /// Status of the packet.
-    public var status: Status
-    /// Payload data (0–6 bytes).
-    public var data: [UInt8]
-
-    /// Creates a new body.
-    public init(status: Status, data: [UInt8]) {
-        precondition(data.count <= 6)
-        self.status = status
-        self.data = data
+    /// Creates a body by encoding a manufacturer ID and payload into SysEx7 packets.
+    /// - Parameters:
+    ///   - manufacturerID: 1- or 3-byte manufacturer identifier.
+    ///   - payload: SysEx payload bytes excluding manufacturer ID.
+    ///   - group: UMP group for all resulting packets.
+    /// - Throws: ``SysEx7.StreamError`` if the manufacturer ID or payload are invalid.
+    public init(manufacturerID: [UInt8], payload: [UInt8], group: Uint4) throws {
+        let raw = try SysEx7.fragment(manufacturerID: manufacturerID, payload: payload, group: group.rawValue)
+        self.packets = try raw.map { try SysEx7Packet(parsing: $0) }
     }
 
-    /// Encodes the body into a ``UmpPacket64`` using the supplied group.
-    public func ump(group: Uint4) -> UmpPacket64 {
-        var bytes: [UInt8] = [0x30 | group.rawValue,
-                              (status.rawValue << 4) | UInt8(data.count)]
-        bytes.append(contentsOf: data)
-        if data.count < 6 {
-            bytes.append(contentsOf: Array(repeating: 0, count: 6 - data.count))
+    /// Raw 8-byte packets.
+    public var rawPackets: [[UInt8]] { packets.map { $0.rawBytes } }
+
+    /// Packets as ``UmpPacket64`` values.
+    public var umps: [UmpPacket64] { packets.map { $0.ump } }
+
+    /// Creates a body from raw 8-byte packets. Fails if any packet is invalid.
+    public init?(rawPackets: [[UInt8]]) {
+        var result: [SysEx7Packet] = []
+        result.reserveCapacity(rawPackets.count)
+        for bytes in rawPackets {
+            guard let pkt = SysEx7Packet(rawBytes: bytes) else { return nil }
+            result.append(pkt)
         }
-        return UmpPacket64(rawBytes: bytes)!
+        self.packets = result
     }
 
-    /// Decodes a body from a ``UmpPacket64``.
-    public init?(ump: UmpPacket64) {
-        let bytes = ump.rawBytes
-        let mt = bytes[0] >> 4
-        guard mt == 0x3 else { return nil }
-        let statusNibble = bytes[1] >> 4
-        guard let status = Status(rawValue: statusNibble) else { return nil }
-        let count = Int(bytes[1] & 0x0F)
-        guard count <= 6 else { return nil }
-        let payload = Array(bytes[2..<(2 + count)])
-        self.init(status: status, data: payload)
+    /// Creates a body from UMP packets. Fails if any packet is invalid.
+    public init?(umps: [UmpPacket64]) {
+        self.init(rawPackets: umps.map { $0.rawBytes })
     }
 
-    /// Failable initialiser that throws ``MIDIError`` for malformed packets.
-    public init(parsingUMP ump: UmpPacket64) throws {
-        let bytes = ump.rawBytes
-        let mt = bytes[0] >> 4
-        guard mt == 0x3 else {
-            throw MIDIError.malformedPacket("expected mt 0x3 but got \(mt)")
-        }
-        let statusNibble = bytes[1] >> 4
-        guard let status = Status(rawValue: statusNibble) else {
-            throw MIDIError.malformedPacket("invalid SysEx7 status 0x\(String(statusNibble, radix: 16))")
-        }
-        let count = Int(bytes[1] & 0x0F)
-        guard count <= 6 else {
-            throw MIDIError.malformedPacket("invalid byte count \(count)")
-        }
-        let payload = Array(bytes[2..<(2 + count)])
-        self.init(status: status, data: payload)
+    /// Reassembles the manufacturer ID and payload from the contained packets.
+    /// - Returns: Manufacturer ID and payload bytes.
+    /// - Throws: ``SysEx7.StreamError`` if the packet sequence is malformed.
+    public func manufacturerAndPayload() throws -> (manufacturerID: [UInt8], payload: [UInt8]) {
+        try SysEx7.reassemble(rawPackets)
     }
 }
 

--- a/Sources/MIDI2/SysEx7Packet.swift
+++ b/Sources/MIDI2/SysEx7Packet.swift
@@ -1,3 +1,95 @@
 /// Raw 8-byte Universal MIDI Packet carrying a SysEx7 fragment.
-public struct SysEx7Packet {
+public struct SysEx7Packet: Equatable {
+    /// Status nibble indicating position of this fragment in the SysEx7 stream.
+    public enum Status: UInt8, Equatable {
+        /// Packet contains a complete message (single packet transfer).
+        case complete = 0x0
+        /// First packet of a multi-packet transfer.
+        case start = 0x1
+        /// Continuation packet of a multi-packet transfer.
+        case `continue` = 0x2
+        /// Final packet of a multi-packet transfer.
+        case end = 0x3
+    }
+
+    /// UMP group (0–15).
+    public var group: Uint4
+    /// Status of the packet within the SysEx7 message.
+    public var status: Status
+    /// Payload data bytes (0–6 bytes).
+    public var data: [UInt8]
+
+    /// Number of payload bytes in ``data`` encoded as a 4-bit value.
+    public var byteCount: Uint4 { Uint4(UInt8(data.count))! }
+
+    /// Creates a packet from fields. ``data`` may contain at most six bytes.
+    public init(group: Uint4, status: Status, data: [UInt8]) {
+        precondition(data.count <= 6)
+        self.group = group
+        self.status = status
+        self.data = data
+    }
+
+    /// Raw 8-byte representation of the packet.
+    public var rawBytes: [UInt8] {
+        var bytes: [UInt8] = [0x30 | group.rawValue,
+                              (status.rawValue << 4) | byteCount.rawValue]
+        bytes.append(contentsOf: data)
+        if data.count < 6 {
+            bytes.append(contentsOf: Array(repeating: 0, count: 6 - data.count))
+        }
+        return bytes
+    }
+
+    /// UMP packet view of this SysEx7 fragment.
+    public var ump: UmpPacket64 { UmpPacket64(rawBytes: rawBytes)! }
+
+    /// Creates a packet from raw bytes. Fails if bytes do not form a valid SysEx7 packet.
+    public init?(rawBytes: [UInt8]) {
+        guard rawBytes.count == 8 else { return nil }
+        let mt = rawBytes[0] >> 4
+        guard mt == 0x3 else { return nil }
+        guard let group = Uint4(rawBytes[0] & 0x0F) else { return nil }
+        let statusNibble = rawBytes[1] >> 4
+        guard let status = Status(rawValue: statusNibble) else { return nil }
+        let count = Int(rawBytes[1] & 0x0F)
+        guard count <= 6 else { return nil }
+        let payload = Array(rawBytes[2..<(2 + count)])
+        self.init(group: group, status: status, data: payload)
+    }
+
+    /// Creates a packet from a ``UmpPacket64``.
+    public init?(ump: UmpPacket64) {
+        self.init(rawBytes: ump.rawBytes)
+    }
+
+    /// Failable initialiser that throws ``MIDIError`` for malformed packets.
+    public init(parsing rawBytes: [UInt8]) throws {
+        guard rawBytes.count == 8 else {
+            throw MIDIError.malformedPacket("expected 8 bytes but got \(rawBytes.count)")
+        }
+        let mt = rawBytes[0] >> 4
+        guard mt == 0x3 else {
+            throw MIDIError.malformedPacket("expected mt 0x3 but got \(mt)")
+        }
+        guard let group = Uint4(rawBytes[0] & 0x0F) else {
+            throw MIDIError.malformedPacket("invalid group \(rawBytes[0] & 0x0F)")
+        }
+        let statusNibble = rawBytes[1] >> 4
+        guard let status = Status(rawValue: statusNibble) else {
+            throw MIDIError.malformedPacket("invalid SysEx7 status 0x\(String(statusNibble, radix: 16))")
+        }
+        let count = Int(rawBytes[1] & 0x0F)
+        guard count <= 6 else {
+            throw MIDIError.malformedPacket("invalid byte count \(count)")
+        }
+        let payload = Array(rawBytes[2..<(2 + count)])
+        self.init(group: group, status: status, data: payload)
+    }
+
+    /// Failable initialiser from ``UmpPacket64`` that throws ``MIDIError`` for malformed packets.
+    public init(parsingUMP ump: UmpPacket64) throws {
+        try self.init(parsing: ump.rawBytes)
+    }
 }
+

--- a/Tests/MIDI2Tests/SysEx7BodyTests.swift
+++ b/Tests/MIDI2Tests/SysEx7BodyTests.swift
@@ -2,12 +2,28 @@ import XCTest
 @testable import MIDI2
 
 final class SysEx7BodyTests: XCTestCase {
-    func testRoundTrip() throws {
-        let body = SysEx7Body(status: .start, data: [1,2,3])
-        let packet = body.ump(group: Uint4(0x1)!)
-        let decoded = SysEx7Body(ump: packet)
-        XCTAssertEqual(decoded, body)
+    func testRoundTripGoldenVector() throws {
+        let manufacturer: [UInt8] = [0x7D]
+        let payload: [UInt8] = [0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08]
+        let body = try SysEx7Body(manufacturerID: manufacturer, payload: payload, group: Uint4(0x0)!)
+        let expected: [[UInt8]] = [
+            [0x30, 0x16, 0x7D, 0x01, 0x02, 0x03, 0x04, 0x05],
+            [0x30, 0x33, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00]
+        ]
+        XCTAssertEqual(body.rawPackets, expected)
+        let (mfr, rebuilt) = try body.manufacturerAndPayload()
+        XCTAssertEqual(mfr, manufacturer)
+        XCTAssertEqual(rebuilt, payload)
+    }
 
-        XCTAssertNoThrow(try SysEx7Body(parsingUMP: packet))
+    func testInvalidManufacturer() {
+        XCTAssertThrowsError(try SysEx7Body(manufacturerID: [0x00], payload: [], group: Uint4(0x0)!))
+    }
+
+    func testInvalidPacketSequence() {
+        let pkt1 = SysEx7Packet(group: Uint4(0x0)!, status: .start, data: [0x7D])
+        let pkt2 = SysEx7Packet(group: Uint4(0x0)!, status: .start, data: [0x00])
+        let body = SysEx7Body(packets: [pkt1, pkt2])
+        XCTAssertThrowsError(try body.manufacturerAndPayload())
     }
 }

--- a/Tests/MIDI2Tests/SysEx7PacketTests.swift
+++ b/Tests/MIDI2Tests/SysEx7PacketTests.swift
@@ -2,21 +2,26 @@ import XCTest
 @testable import MIDI2
 
 final class SysEx7PacketTests: XCTestCase {
-    func testFragmentAndReassemble() throws {
-        let manufacturer: [UInt8] = [0x7D]
-        let payload: [UInt8] = [0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08]
-        let packets = try SysEx7.fragment(manufacturerID: manufacturer, payload: payload)
-        let expected: [[UInt8]] = [
-            [0x30, 0x16, 0x7D, 0x01, 0x02, 0x03, 0x04, 0x05],
-            [0x30, 0x33, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00]
-        ]
-        XCTAssertEqual(packets, expected)
-        let (mfr, reassembled) = try SysEx7.reassemble(packets)
-        XCTAssertEqual(mfr, manufacturer)
-        XCTAssertEqual(reassembled, payload)
+    func testRoundTripGoldenVector() throws {
+        let bytes: [UInt8] = [0x30, 0x16, 0x7D, 0x01, 0x02, 0x03, 0x04, 0x05]
+        let packet = try SysEx7Packet(parsing: bytes)
+        XCTAssertEqual(packet.group, Uint4(0x0)!)
+        XCTAssertEqual(packet.status, .start)
+        XCTAssertEqual(packet.byteCount, Uint4(0x6)!)
+        XCTAssertEqual(packet.data, [0x7D, 0x01, 0x02, 0x03, 0x04, 0x05])
+        XCTAssertEqual(packet.rawBytes, bytes)
+        XCTAssertEqual(packet.ump.rawBytes, bytes)
     }
 
-    func testInvalidManufacturer() {
-        XCTAssertThrowsError(try SysEx7.fragment(manufacturerID: [0x00], payload: []))
+    func testInvalidMessageType() {
+        let bad: [UInt8] = [0x40, 0x16, 0x7D, 0x01, 0x02, 0x03, 0x04, 0x05]
+        XCTAssertNil(SysEx7Packet(rawBytes: bad))
+        XCTAssertThrowsError(try SysEx7Packet(parsing: bad))
+    }
+
+    func testInvalidByteCount() {
+        let bad: [UInt8] = [0x30, 0x1F, 0x7D, 0x01, 0x02, 0x03, 0x04, 0x05]
+        XCTAssertNil(SysEx7Packet(rawBytes: bad))
+        XCTAssertThrowsError(try SysEx7Packet(parsing: bad))
     }
 }


### PR DESCRIPTION
## Summary
- add `SysEx7Packet` with group, status and payload plus binary encoding helpers
- introduce `SysEx7Body` for sequences of `SysEx7Packet` with high level encode/decode
- add round-trip and malformed packet tests for SysEx7 data

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689cb63618148333a6a1ab83319be601