### PR TITLE
Add per-note management and channel voice decoding

### DIFF
--- a/Sources/MIDI2/Midi2AssignPerNoteController.swift
+++ b/Sources/MIDI2/Midi2AssignPerNoteController.swift
@@ -20,3 +20,50 @@ public enum Midi2AssignableControllerAddress: Equatable {
         }
     }
 }
+
+/// Assignable Per-Note Controller message.
+///
+/// Conveys a 32-bit value for an assignable per-note controller.  The
+/// controller index is encoded in the fourth byte of the packet and uses the
+/// full 8-bit range.  The note number occupies the third byte.
+public struct Midi2AssignPerNoteController: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let noteNumber: Uint7
+    public let controller: UInt8
+    public let value: UInt32
+
+    public init(group: Uint4, channel: Uint4, noteNumber: Uint7, controller: UInt8, value: UInt32) {
+        self.group = group
+        self.channel = channel
+        self.noteNumber = noteNumber
+        self.controller = controller
+        self.value = value
+    }
+
+    /// Encodes the message to a UMP packet.
+    public func ump() -> UmpPacket64 {
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(0xF) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(noteNumber.rawValue) << 8 |
+                    UInt32(controller)
+        return UmpPacket64(word0: word0, word1: value)
+    }
+
+    /// Decodes a message from a UMP packet.
+    public init?(ump: UmpPacket64) {
+        let mt = (ump.word0 >> 28) & 0xF
+        guard mt == 0x4 else { return nil }
+        let status = (ump.word0 >> 20) & 0xF
+        guard status == 0xF else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        guard let note = Uint7(UInt8((ump.word0 >> 8) & 0xFF)) else { return nil }
+        let controller = UInt8(ump.word0 & 0xFF)
+        guard controller >= 0x80 else { return nil }
+        let value = ump.word1
+        self.init(group: group, channel: channel, noteNumber: note, controller: controller, value: value)
+    }
+}

--- a/Sources/MIDI2/Midi2ChannelVoiceBody.swift
+++ b/Sources/MIDI2/Midi2ChannelVoiceBody.swift
@@ -1,3 +1,50 @@
-/// Only fields relevant to the specific status are present.
-public struct Midi2ChannelVoiceBody {
+/// Common 64-bit layout for MIDI 2.0 Channel Voice messages.
+///
+/// Provides access to the generic fields shared by all channel voice messages
+/// and convenience decoding into strongly typed variants.
+public struct Midi2ChannelVoiceBody: Equatable {
+    public let group: Uint4
+    public let status: UInt8
+    public let channel: Uint4
+    public let dataByte1: UInt8
+    public let dataByte2: UInt8
+    public let word1: UInt32
+
+    /// Creates a body from individual components.
+    public init(group: Uint4, status: UInt8, channel: Uint4, dataByte1: UInt8, dataByte2: UInt8, word1: UInt32) {
+        self.group = group
+        self.status = status
+        self.channel = channel
+        self.dataByte1 = dataByte1
+        self.dataByte2 = dataByte2
+        self.word1 = word1
+    }
+
+    /// Encodes the body into a UMP packet.
+    public func ump() -> UmpPacket64 {
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(status & 0xF) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(dataByte1) << 8 |
+                    UInt32(dataByte2)
+        return UmpPacket64(word0: word0, word1: word1)
+    }
+
+    /// Creates a body by parsing a UMP packet.
+    public init?(ump: UmpPacket64) {
+        let mt = (ump.word0 >> 28) & 0xF
+        guard mt == 0x4 else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        let status = UInt8((ump.word0 >> 20) & 0xF)
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        let byte1 = UInt8((ump.word0 >> 8) & 0xFF)
+        let byte2 = UInt8(ump.word0 & 0xFF)
+        self.init(group: group, status: status, channel: channel, dataByte1: byte1, dataByte2: byte2, word1: ump.word1)
+    }
+
+    /// Attempts to decode the body into a strongly typed variant.
+    public func variant() -> Midi2ChannelVoiceVariants? {
+        Midi2ChannelVoiceVariants(ump: ump())
+    }
 }

--- a/Sources/MIDI2/Midi2ChannelVoiceVariants.swift
+++ b/Sources/MIDI2/Midi2ChannelVoiceVariants.swift
@@ -1,3 +1,81 @@
 /// Variants of MIDI 2.0 Channel Voice messages.
-public struct Midi2ChannelVoiceVariants {
+public enum Midi2ChannelVoiceVariants: Equatable {
+    case noteOff(NoteOff)
+    case noteOn(Midi2NoteOn)
+    case polyPressure(PolyPressure)
+    case controlChange(ControlChange)
+    case programChange(ProgramChange)
+    case channelPressure(Midi2ChannelPressure)
+    case pitchBend(PitchBend)
+    case perNoteManagement(Midi2PerNoteManagement)
+    case regPerNoteController(Midi2RegPerNoteController)
+    case assignPerNoteController(Midi2AssignPerNoteController)
+}
+
+public extension Midi2ChannelVoiceVariants {
+    /// Encodes the variant to a 64-bit UMP packet.
+    func ump() -> UmpPacket64 {
+        switch self {
+        case let .noteOff(msg):
+            let p = msg.ump()
+            return UmpPacket64(word0: p.word0, word1: p.word1)
+        case let .noteOn(msg):
+            return msg.ump()
+        case let .polyPressure(msg):
+            let p = msg.ump()
+            return UmpPacket64(word0: p.word0, word1: p.word1)
+        case let .controlChange(msg):
+            let p = msg.ump()
+            return UmpPacket64(word0: p.word0, word1: p.word1)
+        case let .programChange(msg):
+            let p = msg.ump()
+            return UmpPacket64(word0: p.word0, word1: p.word1)
+        case let .channelPressure(msg):
+            return msg.ump()
+        case let .pitchBend(msg):
+            let p = msg.ump()
+            return UmpPacket64(word0: p.word0, word1: p.word1)
+        case let .perNoteManagement(msg):
+            return msg.ump()
+        case let .regPerNoteController(msg):
+            return msg.ump()
+        case let .assignPerNoteController(msg):
+            return msg.ump()
+        }
+    }
+
+    /// Decodes a variant from a UMP packet.
+    init?(ump: UmpPacket64) {
+        let status = UInt8((ump.word0 >> 20) & 0xF)
+        switch status {
+        case 0x8:
+            guard let pkt = NoteOff(ump: Ump64(word0: ump.word0, word1: ump.word1)!) else { return nil }
+            self = .noteOff(pkt)
+        case 0x9:
+            guard let pkt = Midi2NoteOn(ump: ump) else { return nil }
+            self = .noteOn(pkt)
+        case 0xA:
+            guard let pkt = PolyPressure(ump: Ump64(word0: ump.word0, word1: ump.word1)!) else { return nil }
+            self = .polyPressure(pkt)
+        case 0xB:
+            guard let pkt = ControlChange(ump: Ump64(word0: ump.word0, word1: ump.word1)!) else { return nil }
+            self = .controlChange(pkt)
+        case 0xC:
+            guard let pkt = ProgramChange(ump: Ump64(word0: ump.word0, word1: ump.word1)!) else { return nil }
+            self = .programChange(pkt)
+        case 0xD:
+            guard let pkt = Midi2ChannelPressure(ump: ump) else { return nil }
+            self = .channelPressure(pkt)
+        case 0xE:
+            guard let pkt = PitchBend(ump: Ump64(word0: ump.word0, word1: ump.word1)!) else { return nil }
+            self = .pitchBend(pkt)
+        case 0xF:
+            if let msg = Midi2PerNoteManagement(ump: ump) { self = .perNoteManagement(msg); return }
+            if let msg = Midi2RegPerNoteController(ump: ump) { self = .regPerNoteController(msg); return }
+            if let msg = Midi2AssignPerNoteController(ump: ump) { self = .assignPerNoteController(msg); return }
+            return nil
+        default:
+            return nil
+        }
+    }
 }

--- a/Sources/MIDI2/Midi2PerNoteManagement.swift
+++ b/Sources/MIDI2/Midi2PerNoteManagement.swift
@@ -1,3 +1,50 @@
 /// Per-Note Management (D/S flags).
-public struct Midi2PerNoteManagement {
+///
+/// Encodes the detach (D) and reset (S) flags for a specific note number on a
+/// MIDI channel.  The message is transported as a 64-bit UMP Channel Voice
+/// packet with status nibble `0xF`.
+public struct Midi2PerNoteManagement: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let noteNumber: Uint7
+    public let detach: Bool
+    public let reset: Bool
+
+    /// Creates a new per-note management message.
+    public init(group: Uint4, channel: Uint4, noteNumber: Uint7, detach: Bool, reset: Bool) {
+        self.group = group
+        self.channel = channel
+        self.noteNumber = noteNumber
+        self.detach = detach
+        self.reset = reset
+    }
+
+    /// Encodes the message into a 64-bit Universal MIDI Packet.
+    public func ump() -> UmpPacket64 {
+        let flags = (detach ? UInt32(0x02) : 0) | (reset ? UInt32(0x01) : 0)
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(0xF) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(noteNumber.rawValue) << 8 |
+                    flags
+        return UmpPacket64(word0: word0, word1: 0)
+    }
+
+    /// Decodes a per-note management message from a UMP packet.
+    /// Returns `nil` if the packet does not encode such a message.
+    public init?(ump: UmpPacket64) {
+        let mt = (ump.word0 >> 28) & 0xF
+        guard mt == 0x4 else { return nil }
+        let status = (ump.word0 >> 20) & 0xF
+        guard status == 0xF else { return nil }
+        guard ump.word1 == 0 else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        guard let note = Uint7(UInt8((ump.word0 >> 8) & 0xFF)) else { return nil }
+        let flags = UInt8(ump.word0 & 0xFF)
+        let detach = (flags & 0x02) != 0
+        let reset = (flags & 0x01) != 0
+        self.init(group: group, channel: channel, noteNumber: note, detach: detach, reset: reset)
+    }
 }

--- a/Sources/MIDI2/Midi2RegPerNoteController.swift
+++ b/Sources/MIDI2/Midi2RegPerNoteController.swift
@@ -1,3 +1,46 @@
-/// Registered per-note controller address.
-public struct Midi2RegPerNoteController {
+/// Registered Per-Note Controller message.
+///
+/// Carries a 32-bit value for a registered per-note controller index.  The
+/// message uses status nibble `0xF` with the controller index encoded in the
+/// fourth byte and the note number in the third byte.
+public struct Midi2RegPerNoteController: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let noteNumber: Uint7
+    public let controller: UInt8
+    public let value: UInt32
+
+    public init(group: Uint4, channel: Uint4, noteNumber: Uint7, controller: UInt8, value: UInt32) {
+        self.group = group
+        self.channel = channel
+        self.noteNumber = noteNumber
+        self.controller = controller
+        self.value = value
+    }
+
+    /// Encodes the message to a UMP packet.
+    public func ump() -> UmpPacket64 {
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(0xF) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(noteNumber.rawValue) << 8 |
+                    UInt32(controller)
+        return UmpPacket64(word0: word0, word1: value)
+    }
+
+    /// Decodes a message from a UMP packet.
+    public init?(ump: UmpPacket64) {
+        let mt = (ump.word0 >> 28) & 0xF
+        guard mt == 0x4 else { return nil }
+        let status = (ump.word0 >> 20) & 0xF
+        guard status == 0xF else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        guard let note = Uint7(UInt8((ump.word0 >> 8) & 0xFF)) else { return nil }
+        let controller = UInt8(ump.word0 & 0xFF)
+        guard controller < 0x80 else { return nil }
+        let value = ump.word1
+        self.init(group: group, channel: channel, noteNumber: note, controller: controller, value: value)
+    }
 }

--- a/Tests/MIDI2Tests/Midi2AssignPerNoteControllerTests.swift
+++ b/Tests/MIDI2Tests/Midi2AssignPerNoteControllerTests.swift
@@ -2,7 +2,10 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2AssignPerNoteControllerTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2AssignPerNoteController
+    func testEncodeDecode() {
+        let msg = Midi2AssignPerNoteController(group: Uint4(1)!, channel: Uint4(2)!, noteNumber: Uint7(70)!, controller: 0x90, value: 0x01020304)
+        let pkt = msg.ump()
+        let decoded = Midi2AssignPerNoteController(ump: pkt)
+        XCTAssertEqual(decoded, msg)
     }
 }

--- a/Tests/MIDI2Tests/Midi2ChannelVoiceBodyTests.swift
+++ b/Tests/MIDI2Tests/Midi2ChannelVoiceBodyTests.swift
@@ -2,7 +2,20 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2ChannelVoiceBodyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2ChannelVoiceBody
+    func testDecodeNoteOn() {
+        let note = Midi2NoteOn(group: Uint4(1)!, channel: Uint4(2)!, note: Uint7(60)!, velocity: 0x1234)
+        let pkt = note.ump()
+        let body = Midi2ChannelVoiceBody(ump: pkt)
+        XCTAssertNotNil(body)
+        XCTAssertEqual(body?.group, Uint4(1)!)
+        XCTAssertEqual(body?.status, 0x9)
+        XCTAssertEqual(body?.channel, Uint4(2)!)
+        XCTAssertEqual(body?.dataByte1, note.note.rawValue)
+        XCTAssertEqual(body?.dataByte2, note.attributeType.rawValue)
+        if case let .noteOn(decoded)? = body?.variant() {
+            XCTAssertEqual(decoded, note)
+        } else {
+            XCTFail("Expected NoteOn variant")
+        }
     }
 }

--- a/Tests/MIDI2Tests/Midi2ChannelVoiceVariantsTests.swift
+++ b/Tests/MIDI2Tests/Midi2ChannelVoiceVariantsTests.swift
@@ -2,7 +2,24 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2ChannelVoiceVariantsTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2ChannelVoiceVariants
+    func testRoundTrip() {
+        let variants: [Midi2ChannelVoiceVariants] = [
+            .noteOff(NoteOff(group: Uint4(1)!, channel: Uint4(0)!, noteNumber: Uint7(60)!, velocity: 0x4000)),
+            .noteOn(Midi2NoteOn(group: Uint4(1)!, channel: Uint4(1)!, note: Uint7(64)!, velocity: 0x5000)),
+            .polyPressure(PolyPressure(group: Uint4(2)!, channel: Uint4(3)!, noteNumber: Uint7(65)!, pressure: 0x01020304)),
+            .controlChange(ControlChange(group: Uint4(0)!, channel: Uint4(2)!, control: Uint7(10)!, value: 0x11223344)),
+            .programChange(ProgramChange(group: Uint4(3)!, channel: Uint4(1)!, program: Uint7(5)!, bankMsb: Uint7(1)!, bankLsb: Uint7(2)!)),
+            .channelPressure(Midi2ChannelPressure(group: Uint4(0)!, channel: Uint4(0)!, pressure: 0x55667788)),
+            .pitchBend(PitchBend(group: Uint4(2)!, channel: Uint4(2)!, value: 0x10203040)),
+            .perNoteManagement(Midi2PerNoteManagement(group: Uint4(1)!, channel: Uint4(2)!, noteNumber: Uint7(70)!, detach: true, reset: false)),
+            .regPerNoteController(Midi2RegPerNoteController(group: Uint4(1)!, channel: Uint4(0)!, noteNumber: Uint7(55)!, controller: 0x10, value: 0x0A0B0C0D)),
+            .assignPerNoteController(Midi2AssignPerNoteController(group: Uint4(2)!, channel: Uint4(1)!, noteNumber: Uint7(50)!, controller: 0x90, value: 0x0E0F1011))
+        ]
+
+        for variant in variants {
+            let pkt = variant.ump()
+            let decoded = Midi2ChannelVoiceVariants(ump: pkt)
+            XCTAssertEqual(decoded, variant)
+        }
     }
 }

--- a/Tests/MIDI2Tests/Midi2PerNoteManagementTests.swift
+++ b/Tests/MIDI2Tests/Midi2PerNoteManagementTests.swift
@@ -2,7 +2,10 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2PerNoteManagementTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2PerNoteManagement
+    func testEncodeDecode() {
+        let msg = Midi2PerNoteManagement(group: Uint4(3)!, channel: Uint4(1)!, noteNumber: Uint7(64)!, detach: true, reset: false)
+        let pkt = msg.ump()
+        let decoded = Midi2PerNoteManagement(ump: pkt)
+        XCTAssertEqual(decoded, msg)
     }
 }

--- a/Tests/MIDI2Tests/Midi2RegPerNoteControllerTests.swift
+++ b/Tests/MIDI2Tests/Midi2RegPerNoteControllerTests.swift
@@ -2,7 +2,10 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2RegPerNoteControllerTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2RegPerNoteController
+    func testEncodeDecode() {
+        let msg = Midi2RegPerNoteController(group: Uint4(2)!, channel: Uint4(0)!, noteNumber: Uint7(60)!, controller: 0x20, value: 0x12345678)
+        let pkt = msg.ump()
+        let decoded = Midi2RegPerNoteController(ump: pkt)
+        XCTAssertEqual(decoded, msg)
     }
 }


### PR DESCRIPTION
## Summary
- implement MIDI 2 per-note management and controller messages
- add channel voice body abstraction and enum variants
- cover new structures with round-trip unit tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689cbbaaaa148333861f9e7f2d075f12