### PR TITLE
Implement Flex and Clip structures with UMP encoding

### DIFF
--- a/Sources/MIDI2/ClipEnvelope.swift
+++ b/Sources/MIDI2/ClipEnvelope.swift
@@ -1,3 +1,38 @@
 /// Envelope data for MIDI Clip messages.
-public struct ClipEnvelope {
+public struct ClipEnvelope: Equatable {
+    /// Indicates the start of a clip.
+    public var startOfClip: Bool
+    /// Indicates the end of a clip.
+    public var endOfClip: Bool
+    /// Number of pickup bars preceding the clip (16.16 fixed point).
+    public var pickupBars: Double
+
+    public init(startOfClip: Bool = false, endOfClip: Bool = false, pickupBars: Double = 0) {
+        self.startOfClip = startOfClip
+        self.endOfClip = endOfClip
+        self.pickupBars = pickupBars
+    }
+
+    private static let scale: Double = 65536.0
+
+    /// Encodes the envelope into a ``Ump128`` packet.
+    public func encode(group: UInt8 = 0) -> Ump128 {
+        let flags: UInt8 = (startOfClip ? 0x1 : 0) | (endOfClip ? 0x2 : 0)
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(flags)
+        let word1 = UInt32((pickupBars * Self.scale).rounded())
+        return Ump128(word0: word0, word1: word1, word2: 0, word3: 0)!
+    }
+
+    /// Decodes an envelope from a ``Ump128`` packet.
+    public static func decode(_ packet: Ump128) -> ClipEnvelope? {
+        guard packet.messageType == 0xD else { return nil }
+        let flags = UInt8(packet.word0 & 0xFF)
+        let start = (flags & 0x1) != 0
+        let end = (flags & 0x2) != 0
+        let bars = Double(packet.word1) / scale
+        return ClipEnvelope(startOfClip: start, endOfClip: end, pickupBars: bars)
+    }
 }
+

--- a/Sources/MIDI2/FlexChordName.swift
+++ b/Sources/MIDI2/FlexChordName.swift
@@ -1,3 +1,97 @@
 /// Flex: Chord name at position.
-public struct FlexChordName {
+public struct FlexChordName: Equatable {
+    /// Address scope for the chord name.
+    public enum Address: Equatable {
+        case group(Uint4)
+        case channel(group: Uint4, channel: Uint4)
+    }
+
+    /// Address indicating group or channel scope.
+    public var address: Address
+
+    /// Chord name text.
+    public var chord: String
+
+    /// Creates a chord name message.
+    public init(address: Address, chord: String) {
+        self.address = address
+        self.chord = chord
+    }
+
+    private static let statusClass: UInt8 = 0x10
+    private static let status: UInt8 = 0x05
+
+    /// Encodes the message into a 128-bit UMP packet.
+    public func encode() -> Ump128 {
+        let (group, addrByte): (UInt8, UInt8)
+        switch address {
+        case .group(let g):
+            group = g.rawValue
+            addrByte = 0x00
+        case .channel(let g, let c):
+            group = g.rawValue
+            addrByte = 0x10 | c.rawValue
+        }
+
+        var bytes = Array(chord.utf8.prefix(12))
+        bytes += Array(repeating: 0, count: 12 - bytes.count)
+        let word1 = UInt32(bytes[0]) << 24 |
+                    UInt32(bytes[1]) << 16 |
+                    UInt32(bytes[2]) << 8  |
+                    UInt32(bytes[3])
+        let word2 = UInt32(bytes[4]) << 24 |
+                    UInt32(bytes[5]) << 16 |
+                    UInt32(bytes[6]) << 8  |
+                    UInt32(bytes[7])
+        let word3 = UInt32(bytes[8]) << 24 |
+                    UInt32(bytes[9]) << 16 |
+                    UInt32(bytes[10]) << 8 |
+                    UInt32(bytes[11])
+
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8 |
+                    UInt32(addrByte)
+
+        return Ump128(word0: word0, word1: word1, word2: word2, word3: word3)!
+    }
+
+    /// Decodes a chord name from a UMP packet.
+    public static func decode(_ packet: Ump128) -> FlexChordName? {
+        guard packet.messageType == 0xD else { return nil }
+        let sc = UInt8((packet.word0 >> 16) & 0xFF)
+        let st = UInt8((packet.word0 >> 8) & 0xFF)
+        guard sc == statusClass, st == status else { return nil }
+
+        guard let group = Uint4(UInt8((packet.word0 >> 24) & 0xF)) else { return nil }
+        let addrByte = UInt8(packet.word0 & 0xFF)
+        let address: Address
+        if addrByte & 0x10 != 0 {
+            guard let ch = Uint4(addrByte & 0xF) else { return nil }
+            address = .channel(group: group, channel: ch)
+        } else {
+            address = .group(group)
+        }
+
+        let bytes: [UInt8] = [
+            UInt8((packet.word1 >> 24) & 0xFF),
+            UInt8((packet.word1 >> 16) & 0xFF),
+            UInt8((packet.word1 >> 8) & 0xFF),
+            UInt8(packet.word1 & 0xFF),
+            UInt8((packet.word2 >> 24) & 0xFF),
+            UInt8((packet.word2 >> 16) & 0xFF),
+            UInt8((packet.word2 >> 8) & 0xFF),
+            UInt8(packet.word2 & 0xFF),
+            UInt8((packet.word3 >> 24) & 0xFF),
+            UInt8((packet.word3 >> 16) & 0xFF),
+            UInt8((packet.word3 >> 8) & 0xFF),
+            UInt8(packet.word3 & 0xFF)
+        ]
+
+        let strBytes = bytes.prefix { $0 != 0 }
+        let chord = String(bytes: strBytes, encoding: .utf8) ?? ""
+        return FlexChordName(address: address, chord: chord)
+    }
 }
+

--- a/Sources/MIDI2/FlexDataBody.swift
+++ b/Sources/MIDI2/FlexDataBody.swift
@@ -1,3 +1,40 @@
 /// Body payload for Flex Data messages.
-public struct FlexDataBody {
+public enum FlexDataBody: Equatable {
+    case tempo(FlexDataTempo)
+    case chordName(FlexChordName)
+    case text(FlexText)
+    case lyric(FlexLyric)
+
+    /// Encodes the body into a single ``Ump128`` packet.
+    public func encode() -> Ump128 {
+        switch self {
+        case .tempo(let t): return t.encode()
+        case .chordName(let c): return c.encode()
+        case .text(let t): return t.encode()
+        case .lyric(let l): return l.encode()
+        }
+    }
+
+    /// Decodes a body from a ``Ump128`` packet.
+    public init?(packet: Ump128) {
+        let sc = UInt8((packet.word0 >> 16) & 0xFF)
+        let st = UInt8((packet.word0 >> 8) & 0xFF)
+        switch (sc, st) {
+        case (0x10, 0x01):
+            guard let t = FlexDataTempo.decode(packet) else { return nil }
+            self = .tempo(t)
+        case (0x10, 0x05):
+            guard let c = FlexChordName.decode(packet) else { return nil }
+            self = .chordName(c)
+        case (0x11, 0x01):
+            guard let t = FlexText.decode(packet) else { return nil }
+            self = .text(t)
+        case (0x11, 0x02):
+            guard let l = FlexLyric.decode(packet) else { return nil }
+            self = .lyric(l)
+        default:
+            return nil
+        }
+    }
 }
+

--- a/Sources/MIDI2/FlexDataTempo.swift
+++ b/Sources/MIDI2/FlexDataTempo.swift
@@ -1,5 +1,5 @@
 /// Flex: Set Tempo (heuristic mapping to BPM).
-public struct FlexDataTempo {
+public struct FlexDataTempo: Equatable {
     public var beatsPerMinute: Double
 
     public init(beatsPerMinute: Double) {

--- a/Sources/MIDI2/FlexLyric.swift
+++ b/Sources/MIDI2/FlexLyric.swift
@@ -1,3 +1,97 @@
 /// Flex Lyric.
-public struct FlexLyric {
+public struct FlexLyric: Equatable {
+    /// Address scope for the lyric.
+    public enum Address: Equatable {
+        case group(Uint4)
+        case channel(group: Uint4, channel: Uint4)
+    }
+
+    /// Address indicating group or channel scope.
+    public var address: Address
+
+    /// Lyric text payload.
+    public var lyric: String
+
+    /// Creates a lyric message.
+    public init(address: Address, lyric: String) {
+        self.address = address
+        self.lyric = lyric
+    }
+
+    private static let statusClass: UInt8 = 0x11
+    private static let status: UInt8 = 0x02
+
+    /// Encodes the message into a 128-bit UMP packet.
+    public func encode() -> Ump128 {
+        let (group, addrByte): (UInt8, UInt8)
+        switch address {
+        case .group(let g):
+            group = g.rawValue
+            addrByte = 0x00
+        case .channel(let g, let c):
+            group = g.rawValue
+            addrByte = 0x10 | c.rawValue
+        }
+
+        var bytes = Array(lyric.utf8.prefix(12))
+        bytes += Array(repeating: 0, count: 12 - bytes.count)
+        let word1 = UInt32(bytes[0]) << 24 |
+                    UInt32(bytes[1]) << 16 |
+                    UInt32(bytes[2]) << 8  |
+                    UInt32(bytes[3])
+        let word2 = UInt32(bytes[4]) << 24 |
+                    UInt32(bytes[5]) << 16 |
+                    UInt32(bytes[6]) << 8  |
+                    UInt32(bytes[7])
+        let word3 = UInt32(bytes[8]) << 24 |
+                    UInt32(bytes[9]) << 16 |
+                    UInt32(bytes[10]) << 8 |
+                    UInt32(bytes[11])
+
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8 |
+                    UInt32(addrByte)
+
+        return Ump128(word0: word0, word1: word1, word2: word2, word3: word3)!
+    }
+
+    /// Decodes a lyric message from a UMP packet.
+    public static func decode(_ packet: Ump128) -> FlexLyric? {
+        guard packet.messageType == 0xD else { return nil }
+        let sc = UInt8((packet.word0 >> 16) & 0xFF)
+        let st = UInt8((packet.word0 >> 8) & 0xFF)
+        guard sc == statusClass, st == status else { return nil }
+
+        guard let group = Uint4(UInt8((packet.word0 >> 24) & 0xF)) else { return nil }
+        let addrByte = UInt8(packet.word0 & 0xFF)
+        let address: Address
+        if addrByte & 0x10 != 0 {
+            guard let ch = Uint4(addrByte & 0xF) else { return nil }
+            address = .channel(group: group, channel: ch)
+        } else {
+            address = .group(group)
+        }
+
+        let bytes: [UInt8] = [
+            UInt8((packet.word1 >> 24) & 0xFF),
+            UInt8((packet.word1 >> 16) & 0xFF),
+            UInt8((packet.word1 >> 8) & 0xFF),
+            UInt8(packet.word1 & 0xFF),
+            UInt8((packet.word2 >> 24) & 0xFF),
+            UInt8((packet.word2 >> 16) & 0xFF),
+            UInt8((packet.word2 >> 8) & 0xFF),
+            UInt8(packet.word2 & 0xFF),
+            UInt8((packet.word3 >> 24) & 0xFF),
+            UInt8((packet.word3 >> 16) & 0xFF),
+            UInt8((packet.word3 >> 8) & 0xFF),
+            UInt8(packet.word3 & 0xFF)
+        ]
+
+        let strBytes = bytes.prefix { $0 != 0 }
+        let lyric = String(bytes: strBytes, encoding: .utf8) ?? ""
+        return FlexLyric(address: address, lyric: lyric)
+    }
 }
+

--- a/Sources/MIDI2/FlexText.swift
+++ b/Sources/MIDI2/FlexText.swift
@@ -1,3 +1,97 @@
 /// Flex Text.
-public struct FlexText {
+public struct FlexText: Equatable {
+    /// Address scope for the text message.
+    public enum Address: Equatable {
+        case group(Uint4)
+        case channel(group: Uint4, channel: Uint4)
+    }
+
+    /// Address indicating group or channel scope.
+    public var address: Address
+
+    /// Text payload.
+    public var text: String
+
+    /// Creates a text message.
+    public init(address: Address, text: String) {
+        self.address = address
+        self.text = text
+    }
+
+    private static let statusClass: UInt8 = 0x11
+    private static let status: UInt8 = 0x01
+
+    /// Encodes the message into a 128-bit UMP packet.
+    public func encode() -> Ump128 {
+        let (group, addrByte): (UInt8, UInt8)
+        switch address {
+        case .group(let g):
+            group = g.rawValue
+            addrByte = 0x00
+        case .channel(let g, let c):
+            group = g.rawValue
+            addrByte = 0x10 | c.rawValue
+        }
+
+        var bytes = Array(text.utf8.prefix(12))
+        bytes += Array(repeating: 0, count: 12 - bytes.count)
+        let word1 = UInt32(bytes[0]) << 24 |
+                    UInt32(bytes[1]) << 16 |
+                    UInt32(bytes[2]) << 8  |
+                    UInt32(bytes[3])
+        let word2 = UInt32(bytes[4]) << 24 |
+                    UInt32(bytes[5]) << 16 |
+                    UInt32(bytes[6]) << 8  |
+                    UInt32(bytes[7])
+        let word3 = UInt32(bytes[8]) << 24 |
+                    UInt32(bytes[9]) << 16 |
+                    UInt32(bytes[10]) << 8 |
+                    UInt32(bytes[11])
+
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8 |
+                    UInt32(addrByte)
+
+        return Ump128(word0: word0, word1: word1, word2: word2, word3: word3)!
+    }
+
+    /// Decodes a text message from a UMP packet.
+    public static func decode(_ packet: Ump128) -> FlexText? {
+        guard packet.messageType == 0xD else { return nil }
+        let sc = UInt8((packet.word0 >> 16) & 0xFF)
+        let st = UInt8((packet.word0 >> 8) & 0xFF)
+        guard sc == statusClass, st == status else { return nil }
+
+        guard let group = Uint4(UInt8((packet.word0 >> 24) & 0xF)) else { return nil }
+        let addrByte = UInt8(packet.word0 & 0xFF)
+        let address: Address
+        if addrByte & 0x10 != 0 {
+            guard let ch = Uint4(addrByte & 0xF) else { return nil }
+            address = .channel(group: group, channel: ch)
+        } else {
+            address = .group(group)
+        }
+
+        let bytes: [UInt8] = [
+            UInt8((packet.word1 >> 24) & 0xFF),
+            UInt8((packet.word1 >> 16) & 0xFF),
+            UInt8((packet.word1 >> 8) & 0xFF),
+            UInt8(packet.word1 & 0xFF),
+            UInt8((packet.word2 >> 24) & 0xFF),
+            UInt8((packet.word2 >> 16) & 0xFF),
+            UInt8((packet.word2 >> 8) & 0xFF),
+            UInt8(packet.word2 & 0xFF),
+            UInt8((packet.word3 >> 24) & 0xFF),
+            UInt8((packet.word3 >> 16) & 0xFF),
+            UInt8((packet.word3 >> 8) & 0xFF),
+            UInt8(packet.word3 & 0xFF)
+        ]
+
+        let strBytes = bytes.prefix { $0 != 0 }
+        let text = String(bytes: strBytes, encoding: .utf8) ?? ""
+        return FlexText(address: address, text: text)
+    }
 }
+

--- a/Tests/MIDI2Tests/ClipEnvelopeTests.swift
+++ b/Tests/MIDI2Tests/ClipEnvelopeTests.swift
@@ -2,7 +2,14 @@ import XCTest
 @testable import MIDI2
 
 final class ClipEnvelopeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test ClipEnvelope
+    func testRoundTrip() {
+        let env = ClipEnvelope(startOfClip: true, endOfClip: false, pickupBars: 1.25)
+        let packet = env.encode(group: 3)
+        XCTAssertEqual(ClipEnvelope.decode(packet), env)
+    }
+
+    func testMalformed() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(ClipEnvelope.decode(bad))
     }
 }

--- a/Tests/MIDI2Tests/FlexChordNameTests.swift
+++ b/Tests/MIDI2Tests/FlexChordNameTests.swift
@@ -2,7 +2,15 @@ import XCTest
 @testable import MIDI2
 
 final class FlexChordNameTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexChordName
+    func testRoundTrip() {
+        let addr = FlexChordName.Address.channel(group: Uint4(1)!, channel: Uint4(2)!)
+        let msg = FlexChordName(address: addr, chord: "Cmaj7")
+        let packet = msg.encode()
+        XCTAssertEqual(FlexChordName.decode(packet), msg)
+    }
+
+    func testMalformed() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexChordName.decode(bad))
     }
 }

--- a/Tests/MIDI2Tests/FlexDataBodyTests.swift
+++ b/Tests/MIDI2Tests/FlexDataBodyTests.swift
@@ -2,7 +2,14 @@ import XCTest
 @testable import MIDI2
 
 final class FlexDataBodyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexDataBody
+    func testDecodeTempo() {
+        let tempo = FlexDataTempo(beatsPerMinute: 90)
+        let pkt = tempo.encode()
+        XCTAssertEqual(FlexDataBody(packet: pkt), .tempo(tempo))
+    }
+
+    func testUnknown() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexDataBody(packet: bad))
     }
 }

--- a/Tests/MIDI2Tests/FlexDataTempoTests.swift
+++ b/Tests/MIDI2Tests/FlexDataTempoTests.swift
@@ -19,4 +19,9 @@ final class FlexDataTempoTests: XCTestCase {
         guard let decoded = FlexDataTempo.decode(packet) else { return XCTFail("decode failed") }
         XCTAssertEqual(decoded.beatsPerMinute, 120, accuracy: 0.0001)
     }
+
+    func testMalformedDecode() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexDataTempo.decode(bad))
+    }
 }

--- a/Tests/MIDI2Tests/FlexLyricTests.swift
+++ b/Tests/MIDI2Tests/FlexLyricTests.swift
@@ -2,7 +2,15 @@ import XCTest
 @testable import MIDI2
 
 final class FlexLyricTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexLyric
+    func testRoundTrip() {
+        let addr = FlexLyric.Address.group(Uint4(0)!)
+        let msg = FlexLyric(address: addr, lyric: "la")
+        let packet = msg.encode()
+        XCTAssertEqual(FlexLyric.decode(packet), msg)
+    }
+
+    func testMalformed() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexLyric.decode(bad))
     }
 }

--- a/Tests/MIDI2Tests/FlexTextTests.swift
+++ b/Tests/MIDI2Tests/FlexTextTests.swift
@@ -2,7 +2,15 @@ import XCTest
 @testable import MIDI2
 
 final class FlexTextTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexText
+    func testRoundTrip() {
+        let addr = FlexText.Address.group(Uint4(3)!)
+        let msg = FlexText(address: addr, text: "Hello")
+        let packet = msg.encode()
+        XCTAssertEqual(FlexText.decode(packet), msg)
+    }
+
+    func testMalformed() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexText.decode(bad))
     }
 }


### PR DESCRIPTION
## Summary
- add Flex chord, text, and lyric types with scoped addressing and UMP encode/decode
- represent clip envelopes with start/end flags and pickup bars
- decode FlexDataBody variants and test malformed cases for tempo/chord/lyric

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689cbefe30b48333a4c6692ae9bf6551