### PR TITLE
Add SystemStatus integration and system packet tests

### DIFF
--- a/Sources/MIDI2/System/SystemCommon.swift
+++ b/Sources/MIDI2/System/SystemCommon.swift
@@ -14,37 +14,31 @@ public enum SystemCommon: Equatable {
         }
     }
 
-    private var status: UInt8 {
+    private var status: SystemStatus {
         switch self {
-        case .mtcQuarterFrame: return 0xF1
-        case .songPositionPointer: return 0xF2
-        case .songSelect: return 0xF3
-        case .tuneRequest: return 0xF6
+        case .mtcQuarterFrame: return .mtcQuarterFrame
+        case .songPositionPointer: return .songPositionPointer
+        case .songSelect: return .songSelect
+        case .tuneRequest: return .tuneRequest
         }
     }
 
     /// Encodes the message into a 32-bit UMP packet.
     public func ump() -> UmpPacket32 {
-        let byte0 = UInt32(0x1 << 4 | group.rawValue)
-        let status = UInt32(self.status)
-        let data1: UInt32
-        let data2: UInt32
+        let body: SystemCommonRealtimeBody
         switch self {
         case .mtcQuarterFrame(_, let message):
-            data1 = UInt32(message.rawValue)
-            data2 = 0
+            body = SystemCommonRealtimeBody(status: status, data1: message.rawValue)
         case .songPositionPointer(_, let position):
-            data1 = UInt32(position.rawValue & 0x7F)
-            data2 = UInt32((position.rawValue >> 7) & 0x7F)
+            let lsb = UInt8(position.rawValue & 0x7F)
+            let msb = UInt8((position.rawValue >> 7) & 0x7F)
+            body = SystemCommonRealtimeBody(status: status, data1: lsb, data2: msb)
         case .songSelect(_, let song):
-            data1 = UInt32(song.rawValue)
-            data2 = 0
+            body = SystemCommonRealtimeBody(status: status, data1: song.rawValue)
         case .tuneRequest:
-            data1 = 0
-            data2 = 0
+            body = SystemCommonRealtimeBody(status: status)
         }
-        let word = (byte0 << 24) | (status << 16) | (data1 << 8) | data2
-        return UmpPacket32(word: word)
+        return body.ump(group: group)
     }
 
     /// Decodes a 32-bit UMP packet.
@@ -53,22 +47,19 @@ public enum SystemCommon: Equatable {
         guard mt == 0x1 else { return nil }
         let byte0 = UInt8((ump.word >> 24) & 0xFF)
         guard let group = Uint4(byte0 & 0x0F) else { return nil }
-        let status = UInt8((ump.word >> 16) & 0xFF)
-        guard status >> 4 == 0xF else { return nil }
-        let data1 = UInt8((ump.word >> 8) & 0xFF)
-        let data2 = UInt8(ump.word & 0xFF)
-        switch status {
-        case 0xF1:
-            guard let msg = Uint7(data1) else { return nil }
+        guard let body = SystemCommonRealtimeBody(ump: ump) else { return nil }
+        switch body.status {
+        case .mtcQuarterFrame:
+            guard let msg = Uint7(body.data1) else { return nil }
             self = .mtcQuarterFrame(group: group, message: msg)
-        case 0xF2:
-            let value = UInt16(data1 & 0x7F) | (UInt16(data2 & 0x7F) << 7)
+        case .songPositionPointer:
+            let value = UInt16(body.data1 & 0x7F) | (UInt16(body.data2 & 0x7F) << 7)
             guard let pos = Uint14(value) else { return nil }
             self = .songPositionPointer(group: group, position: pos)
-        case 0xF3:
-            guard let song = Uint7(data1) else { return nil }
+        case .songSelect:
+            guard let song = Uint7(body.data1) else { return nil }
             self = .songSelect(group: group, song: song)
-        case 0xF6:
+        case .tuneRequest:
             self = .tuneRequest(group: group)
         default:
             return nil
@@ -82,27 +73,22 @@ public enum SystemCommon: Equatable {
         }
         let byte0 = UInt8((ump.word >> 24) & 0xFF)
         let group = try Uint4(validating: byte0 & 0x0F)
-        let status = UInt8((ump.word >> 16) & 0xFF)
-        guard status >> 4 == 0xF else {
-            throw MIDIError.malformedPacket("invalid system common status 0x\(String(status, radix: 16))")
-        }
-        let data1 = UInt8((ump.word >> 8) & 0xFF)
-        let data2 = UInt8(ump.word & 0xFF)
-        switch status {
-        case 0xF1:
-            let msg = try Uint7(validating: data1)
+        let body = try SystemCommonRealtimeBody(parsingUMP: ump)
+        switch body.status {
+        case .mtcQuarterFrame:
+            let msg = try Uint7(validating: body.data1)
             self = .mtcQuarterFrame(group: group, message: msg)
-        case 0xF2:
-            let value = UInt16(data1 & 0x7F) | (UInt16(data2 & 0x7F) << 7)
+        case .songPositionPointer:
+            let value = UInt16(body.data1 & 0x7F) | (UInt16(body.data2 & 0x7F) << 7)
             let pos = try Uint14(validating: value)
             self = .songPositionPointer(group: group, position: pos)
-        case 0xF3:
-            let song = try Uint7(validating: data1)
+        case .songSelect:
+            let song = try Uint7(validating: body.data1)
             self = .songSelect(group: group, song: song)
-        case 0xF6:
+        case .tuneRequest:
             self = .tuneRequest(group: group)
         default:
-            throw MIDIError.malformedPacket("unsupported system common status 0x\(String(status, radix: 16))")
+            throw MIDIError.malformedPacket("unsupported system common status 0x\(String(body.status.rawValue, radix: 16))")
         }
     }
 }

--- a/Sources/MIDI2/System/SystemRealTime.swift
+++ b/Sources/MIDI2/System/SystemRealTime.swift
@@ -16,22 +16,21 @@ public enum SystemRealTime: Equatable {
         }
     }
 
-    private var status: UInt8 {
+    private var status: SystemStatus {
         switch self {
-        case .timingClock: return 0xF8
-        case .start: return 0xFA
-        case .continue: return 0xFB
-        case .stop: return 0xFC
-        case .activeSensing: return 0xFE
-        case .systemReset: return 0xFF
+        case .timingClock: return .timingClock
+        case .start: return .start
+        case .continue: return .continue
+        case .stop: return .stop
+        case .activeSensing: return .activeSensing
+        case .systemReset: return .systemReset
         }
     }
 
     /// Encodes the message into a 32-bit UMP packet.
     public func ump() -> UmpPacket32 {
-        let byte0 = UInt32(0x1 << 4 | group.rawValue)
-        let word = (byte0 << 24) | (UInt32(status) << 16)
-        return UmpPacket32(word: word)
+        let body = SystemCommonRealtimeBody(status: status)
+        return body.ump(group: group)
     }
 
     /// Decodes a 32-bit UMP packet.
@@ -40,16 +39,37 @@ public enum SystemRealTime: Equatable {
         guard mt == 0x1 else { return nil }
         let byte0 = UInt8((ump.word >> 24) & 0xFF)
         guard let group = Uint4(byte0 & 0x0F) else { return nil }
-        let status = UInt8((ump.word >> 16) & 0xFF)
-        guard status >> 4 == 0xF else { return nil }
-        switch status {
-        case 0xF8: self = .timingClock(group: group)
-        case 0xFA: self = .start(group: group)
-        case 0xFB: self = .continue(group: group)
-        case 0xFC: self = .stop(group: group)
-        case 0xFE: self = .activeSensing(group: group)
-        case 0xFF: self = .systemReset(group: group)
+        guard let body = SystemCommonRealtimeBody(ump: ump) else { return nil }
+        switch body.status {
+        case .timingClock: self = .timingClock(group: group)
+        case .start: self = .start(group: group)
+        case .continue: self = .continue(group: group)
+        case .stop: self = .stop(group: group)
+        case .activeSensing: self = .activeSensing(group: group)
+        case .systemReset: self = .systemReset(group: group)
         default: return nil
+        }
+    }
+
+    /// Failable initialiser that performs validation and throws `MIDIError` on
+    /// malformed packets.
+    public init(parsingUMP ump: UmpPacket32) throws {
+        let mt = UInt8((ump.word >> 28) & 0xF)
+        guard mt == 0x1 else {
+            throw MIDIError.malformedPacket("expected mt 0x1 but got \(mt)")
+        }
+        let byte0 = UInt8((ump.word >> 24) & 0xFF)
+        let group = try Uint4(validating: byte0 & 0x0F)
+        let body = try SystemCommonRealtimeBody(parsingUMP: ump)
+        switch body.status {
+        case .timingClock: self = .timingClock(group: group)
+        case .start: self = .start(group: group)
+        case .continue: self = .continue(group: group)
+        case .stop: self = .stop(group: group)
+        case .activeSensing: self = .activeSensing(group: group)
+        case .systemReset: self = .systemReset(group: group)
+        default:
+            throw MIDIError.malformedPacket("unsupported system realtime status 0x\(String(body.status.rawValue, radix: 16))")
         }
     }
 }

--- a/Tests/MIDI2Tests/System/SystemCommonErrorTests.swift
+++ b/Tests/MIDI2Tests/System/SystemCommonErrorTests.swift
@@ -8,7 +8,15 @@ final class SystemCommonErrorTests: XCTestCase {
         let word = (byte0 << 24) | (status << 16)
         let ump = UmpPacket32(word: word)
         XCTAssertThrowsError(try SystemCommon(parsingUMP: ump)) { error in
-            XCTAssertTrue(error.localizedDescription.contains("unsupported system common status"))
+            XCTAssertTrue(error.localizedDescription.contains("invalid system status"))
+        }
+    }
+
+    func testInvalidMessageType() {
+        let word = UInt32(0x2 << 28)
+        let ump = UmpPacket32(word: word)
+        XCTAssertThrowsError(try SystemCommon(parsingUMP: ump)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("expected mt 0x1"))
         }
     }
 }

--- a/Tests/MIDI2Tests/System/SystemCommonTests.swift
+++ b/Tests/MIDI2Tests/System/SystemCommonTests.swift
@@ -2,6 +2,20 @@ import XCTest
 @testable import MIDI2
 
 final class SystemCommonTests: XCTestCase {
+    func testRoundTripMTCQuarterFrame() {
+        let msg = SystemCommon.mtcQuarterFrame(group: Uint4(0x1)!, message: Uint7(0x10)!)
+        let ump = msg.ump()
+        let decoded = SystemCommon(ump: ump)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testRoundTripSongSelect() {
+        let msg = SystemCommon.songSelect(group: Uint4(0x2)!, song: Uint7(0x7F)!)
+        let ump = msg.ump()
+        let decoded = SystemCommon(ump: ump)
+        XCTAssertEqual(decoded, msg)
+    }
+
     func testRoundTripSongPosition() {
         let msg = SystemCommon.songPositionPointer(group: Uint4(0x3)!, position: Uint14(0x1FFF)!)
         let ump = msg.ump()
@@ -21,6 +35,13 @@ final class SystemCommonTests: XCTestCase {
         let byte0 = UInt32(0x1 << 4 | 0x1)
         let status = UInt32(0xF4)
         let word = (byte0 << 24) | (status << 16)
+        let ump = UmpPacket32(word: word)
+        XCTAssertNil(SystemCommon(ump: ump))
+    }
+
+    func testMalformedMessageType() {
+        // mt field not equal to 0x1
+        let word = UInt32(0x2 << 28)
         let ump = UmpPacket32(word: word)
         XCTAssertNil(SystemCommon(ump: ump))
     }

--- a/Tests/MIDI2Tests/System/SystemRealTimeTests.swift
+++ b/Tests/MIDI2Tests/System/SystemRealTimeTests.swift
@@ -2,11 +2,22 @@ import XCTest
 @testable import MIDI2
 
 final class SystemRealTimeTests: XCTestCase {
-    func testRoundTripClock() {
-        let msg = SystemRealTime.timingClock(group: Uint4(0x2)!)
-        let ump = msg.ump()
-        let decoded = SystemRealTime(ump: ump)
-        XCTAssertEqual(decoded, msg)
+    func testRoundTripAllMessages() {
+        let cases: [SystemRealTime] = [
+            .timingClock(group: Uint4(0x0)!),
+            .start(group: Uint4(0x1)!),
+            .continue(group: Uint4(0x2)!),
+            .stop(group: Uint4(0x3)!),
+            .activeSensing(group: Uint4(0x4)!),
+            .systemReset(group: Uint4(0x5)!)
+        ]
+
+        for msg in cases {
+            let ump = msg.ump()
+            let decoded = SystemRealTime(ump: ump)
+            XCTAssertEqual(decoded, msg)
+            XCTAssertNoThrow(try SystemRealTime(parsingUMP: ump))
+        }
     }
 
     func testMalformedStatus() {
@@ -15,5 +26,14 @@ final class SystemRealTimeTests: XCTestCase {
         let word = (byte0 << 24) | (UInt32(0xF1) << 16)
         let ump = UmpPacket32(word: word)
         XCTAssertNil(SystemRealTime(ump: ump))
+        XCTAssertThrowsError(try SystemRealTime(parsingUMP: ump))
+    }
+
+    func testMalformedMessageType() {
+        // mt field not equal to 0x1
+        let word = UInt32(0x2 << 28)
+        let ump = UmpPacket32(word: word)
+        XCTAssertNil(SystemRealTime(ump: ump))
+        XCTAssertThrowsError(try SystemRealTime(parsingUMP: ump))
     }
 }

--- a/Tests/MIDI2Tests/SystemCommonRealtimeBodyTests.swift
+++ b/Tests/MIDI2Tests/SystemCommonRealtimeBodyTests.swift
@@ -2,12 +2,43 @@ import XCTest
 @testable import MIDI2
 
 final class SystemCommonRealtimeBodyTests: XCTestCase {
-    func testRoundTripSongSelect() throws {
-        let body = SystemCommonRealtimeBody(status: .songSelect, data1: 0x7F)
-        let packet = body.ump(group: Uint4(0x3)!)
-        let decoded = SystemCommonRealtimeBody(ump: packet)
-        XCTAssertEqual(decoded, body)
+    func testRoundTripAllStatuses() throws {
+        let group = Uint4(0x3)!
+        let cases: [(SystemStatus, UInt8, UInt8)] = [
+            (.mtcQuarterFrame, 0x10, 0),
+            (.songPositionPointer, 0x01, 0x02),
+            (.songSelect, 0x7F, 0),
+            (.tuneRequest, 0, 0),
+            (.timingClock, 0, 0),
+            (.start, 0, 0),
+            (.continue, 0, 0),
+            (.stop, 0, 0),
+            (.activeSensing, 0, 0),
+            (.systemReset, 0, 0)
+        ]
 
-        XCTAssertNoThrow(try SystemCommonRealtimeBody(parsingUMP: packet))
+        for (status, d1, d2) in cases {
+            let body = SystemCommonRealtimeBody(status: status, data1: d1, data2: d2)
+            let packet = body.ump(group: group)
+            let decoded = SystemCommonRealtimeBody(ump: packet)
+            XCTAssertEqual(decoded, body)
+            XCTAssertNoThrow(try SystemCommonRealtimeBody(parsingUMP: packet))
+        }
+    }
+
+    func testInvalidMessageType() {
+        // mt field not equal to 0x1
+        let word = UInt32(0x2 << 28)
+        let packet = UmpPacket32(word: word)
+        XCTAssertNil(SystemCommonRealtimeBody(ump: packet))
+        XCTAssertThrowsError(try SystemCommonRealtimeBody(parsingUMP: packet))
+    }
+
+    func testInvalidStatus() {
+        // status byte 0xF4 is undefined
+        let word = (UInt32(0x1 << 28) | (UInt32(0xF4) << 16))
+        let packet = UmpPacket32(word: word)
+        XCTAssertNil(SystemCommonRealtimeBody(ump: packet))
+        XCTAssertThrowsError(try SystemCommonRealtimeBody(parsingUMP: packet))
     }
 }

--- a/Tests/MIDI2Tests/SystemStatusTests.swift
+++ b/Tests/MIDI2Tests/SystemStatusTests.swift
@@ -2,7 +2,30 @@ import XCTest
 @testable import MIDI2
 
 final class SystemStatusTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test SystemStatus
+    func testRawValues() {
+        XCTAssertEqual(SystemStatus.mtcQuarterFrame.rawValue, 0xF1)
+        XCTAssertEqual(SystemStatus.songPositionPointer.rawValue, 0xF2)
+        XCTAssertEqual(SystemStatus.songSelect.rawValue, 0xF3)
+        XCTAssertEqual(SystemStatus.tuneRequest.rawValue, 0xF6)
+        XCTAssertEqual(SystemStatus.timingClock.rawValue, 0xF8)
+        XCTAssertEqual(SystemStatus.start.rawValue, 0xFA)
+        XCTAssertEqual(SystemStatus.continue.rawValue, 0xFB)
+        XCTAssertEqual(SystemStatus.stop.rawValue, 0xFC)
+        XCTAssertEqual(SystemStatus.activeSensing.rawValue, 0xFE)
+        XCTAssertEqual(SystemStatus.systemReset.rawValue, 0xFF)
+    }
+
+    func testInitFromRawValue() {
+        XCTAssertEqual(SystemStatus(rawValue: 0xF1), .mtcQuarterFrame)
+        XCTAssertEqual(SystemStatus(rawValue: 0xF2), .songPositionPointer)
+        XCTAssertEqual(SystemStatus(rawValue: 0xF3), .songSelect)
+        XCTAssertEqual(SystemStatus(rawValue: 0xF6), .tuneRequest)
+        XCTAssertEqual(SystemStatus(rawValue: 0xF8), .timingClock)
+        XCTAssertEqual(SystemStatus(rawValue: 0xFA), .start)
+        XCTAssertEqual(SystemStatus(rawValue: 0xFB), .continue)
+        XCTAssertEqual(SystemStatus(rawValue: 0xFC), .stop)
+        XCTAssertEqual(SystemStatus(rawValue: 0xFE), .activeSensing)
+        XCTAssertEqual(SystemStatus(rawValue: 0xFF), .systemReset)
+        XCTAssertNil(SystemStatus(rawValue: 0xF4))
     }
 }


### PR DESCRIPTION
## Summary
- integrate `SystemStatus` into SystemCommon and SystemRealTime models
- add unified body for encoding/decoding system packets
- expand system tests with round-trip and negative cases

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689cc16667bc83338199d798ba6f11d6