### PR TITLE
Add tests and fuzzers for MIDI2 numeric wrappers and opcodes

### DIFF
--- a/Tests/Fuzz/Uint14FuzzTests.swift
+++ b/Tests/Fuzz/Uint14FuzzTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+import SwiftCheck
+@testable import MIDI2
+
+final class Uint14FuzzTests: XCTestCase {
+    func testUint14Range() {
+        property("Uint14 validates range") <- forAll { (x: UInt16) in
+            if x < 0x4000 {
+                return (try? Uint14(validating: x)) != nil
+            } else {
+                return (try? Uint14(validating: x)) == nil
+            }
+        }
+    }
+}

--- a/Tests/Fuzz/Uint4FuzzTests.swift
+++ b/Tests/Fuzz/Uint4FuzzTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+import SwiftCheck
+@testable import MIDI2
+
+final class Uint4FuzzTests: XCTestCase {
+    func testUint4Range() {
+        property("Uint4 validates range") <- forAll { (x: UInt8) in
+            if x < 0x10 {
+                return (try? Uint4(validating: x)) != nil
+            } else {
+                return (try? Uint4(validating: x)) == nil
+            }
+        }
+    }
+}

--- a/Tests/MIDI2Tests/DataMessageKindTests.swift
+++ b/Tests/MIDI2Tests/DataMessageKindTests.swift
@@ -2,7 +2,11 @@ import XCTest
 @testable import MIDI2
 
 final class DataMessageKindTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test DataMessageKind
+    func testKindFromBody() {
+        let body = DataMessageBody.sysex8(manufacturerID: [0x7D], data: [0x01])
+        XCTAssertEqual(body.kind, .sysex8)
+
+        let mds = DataMessageBody.mds
+        XCTAssertEqual(mds.kind, .mds)
     }
 }

--- a/Tests/MIDI2Tests/StreamOpcodeTests.swift
+++ b/Tests/MIDI2Tests/StreamOpcodeTests.swift
@@ -2,7 +2,16 @@ import XCTest
 @testable import MIDI2
 
 final class StreamOpcodeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test StreamOpcode
+    func testRawValues() {
+        XCTAssertEqual(StreamOpcode.endpointDiscovery.rawValue, 0x00)
+        XCTAssertEqual(StreamOpcode.streamConfiguration.rawValue, 0x01)
+        XCTAssertEqual(StreamOpcode.functionBlock.rawValue, 0x02)
+    }
+
+    func testInitFromRaw() {
+        XCTAssertEqual(StreamOpcode(rawValue: 0x00), .endpointDiscovery)
+        XCTAssertEqual(StreamOpcode(rawValue: 0x01), .streamConfiguration)
+        XCTAssertEqual(StreamOpcode(rawValue: 0x02), .functionBlock)
+        XCTAssertNil(StreamOpcode(rawValue: 0x03))
     }
 }

--- a/Tests/MIDI2Tests/Uint14Tests.swift
+++ b/Tests/MIDI2Tests/Uint14Tests.swift
@@ -2,7 +2,33 @@ import XCTest
 @testable import MIDI2
 
 final class Uint14Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Uint14
+    func testRoundTrip() throws {
+        let raw: UInt16 = 0x3FFF
+        let uint = try XCTUnwrap(Uint14(raw))
+        XCTAssertEqual(uint.rawValue, raw)
+    }
+
+    func testGoldenVectors() {
+        XCTAssertEqual(Uint14(0x0000)?.rawValue, 0x0000)
+        XCTAssertEqual(Uint14(0x3FFF)?.rawValue, 0x3FFF)
+    }
+
+    func testError() {
+        XCTAssertNil(Uint14(0x4000))
+        XCTAssertThrowsError(try Uint14(validating: 0x4000))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt16.random(in: 0x0...0x3FFF)
+            let uint = try Uint14(validating: raw)
+            XCTAssertEqual(uint.rawValue, raw)
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt16.random(in: 0x4000...UInt16.max)
+            XCTAssertNil(Uint14(raw))
+            XCTAssertThrowsError(try Uint14(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/Uint4Tests.swift
+++ b/Tests/MIDI2Tests/Uint4Tests.swift
@@ -2,7 +2,33 @@ import XCTest
 @testable import MIDI2
 
 final class Uint4Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Uint4
+    func testRoundTrip() throws {
+        let raw: UInt8 = 0xF
+        let uint = try XCTUnwrap(Uint4(raw))
+        XCTAssertEqual(uint.rawValue, raw)
+    }
+
+    func testGoldenVectors() {
+        XCTAssertEqual(Uint4(0x0)?.rawValue, 0x0)
+        XCTAssertEqual(Uint4(0xF)?.rawValue, 0xF)
+    }
+
+    func testError() {
+        XCTAssertNil(Uint4(0x10))
+        XCTAssertThrowsError(try Uint4(validating: 0x10))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt8.random(in: 0x0...0xF)
+            let uint = try Uint4(validating: raw)
+            XCTAssertEqual(uint.rawValue, raw)
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt8.random(in: 0x10...UInt8.max)
+            XCTAssertNil(Uint4(raw))
+            XCTAssertThrowsError(try Uint4(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/Uint7Tests.swift
+++ b/Tests/MIDI2Tests/Uint7Tests.swift
@@ -2,7 +2,33 @@ import XCTest
 @testable import MIDI2
 
 final class Uint7Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Uint7
+    func testRoundTrip() throws {
+        let raw: UInt8 = 0x7F
+        let uint = try XCTUnwrap(Uint7(raw))
+        XCTAssertEqual(uint.rawValue, raw)
+    }
+
+    func testGoldenVectors() {
+        XCTAssertEqual(Uint7(0x00)?.rawValue, 0x00)
+        XCTAssertEqual(Uint7(0x7F)?.rawValue, 0x7F)
+    }
+
+    func testError() {
+        XCTAssertNil(Uint7(0x80))
+        XCTAssertThrowsError(try Uint7(validating: 0x80))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt8.random(in: 0x0...0x7F)
+            let uint = try Uint7(validating: raw)
+            XCTAssertEqual(uint.rawValue, raw)
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt8.random(in: 0x80...UInt8.max)
+            XCTAssertNil(Uint7(raw))
+            XCTAssertThrowsError(try Uint7(validating: raw))
+        }
     }
 }

--- a/Tests/MIDI2Tests/UmpPacket128Tests.swift
+++ b/Tests/MIDI2Tests/UmpPacket128Tests.swift
@@ -2,7 +2,30 @@ import XCTest
 @testable import MIDI2
 
 final class UmpPacket128Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UmpPacket128
+    func testRoundTripWords() {
+        let packet = UmpPacket128(
+            word0: 0x11223344,
+            word1: 0x55667788,
+            word2: 0x99AABBCC,
+            word3: 0xDDEEFF00
+        )
+        let reconstructed = UmpPacket128(words: packet.words)
+        XCTAssertEqual(reconstructed, packet)
+    }
+
+    func testHeader() {
+        let headerWord: UInt32 = 0x41234567
+        let packet = UmpPacket128(
+            word0: headerWord,
+            word1: 0x89ABCDEF,
+            word2: 0x01234567,
+            word3: 0x89ABCDEF
+        )
+        XCTAssertEqual(packet.header.word, headerWord)
+    }
+
+    func testInitInvalidCount() {
+        XCTAssertNil(UmpPacket128(words: [0x1]))
+        XCTAssertNil(UmpPacket128(words: [0x1, 0x2, 0x3]))
     }
 }

--- a/Tests/MIDI2Tests/UmpPacket64Tests.swift
+++ b/Tests/MIDI2Tests/UmpPacket64Tests.swift
@@ -2,7 +2,20 @@ import XCTest
 @testable import MIDI2
 
 final class UmpPacket64Tests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UmpPacket64
+    func testRoundTripWords() {
+        let packet = UmpPacket64(word0: 0x11223344, word1: 0x55667788)
+        let reconstructed = UmpPacket64(words: packet.words)
+        XCTAssertEqual(reconstructed, packet)
+    }
+
+    func testHeader() {
+        let headerWord: UInt32 = 0x41234567
+        let packet = UmpPacket64(word0: headerWord, word1: 0x89ABCDEF)
+        XCTAssertEqual(packet.header.word, headerWord)
+    }
+
+    func testInitInvalidCount() {
+        XCTAssertNil(UmpPacket64(words: [0x1]))
+        XCTAssertNil(UmpPacket64(words: [0x1, 0x2, 0x3]))
     }
 }

--- a/Tests/MIDI2Tests/UtilityOpcodeTests.swift
+++ b/Tests/MIDI2Tests/UtilityOpcodeTests.swift
@@ -2,7 +2,16 @@ import XCTest
 @testable import MIDI2
 
 final class UtilityOpcodeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UtilityOpcode
+    func testRawValues() {
+        XCTAssertEqual(UtilityOpcode.noop.rawValue, 0x00)
+        XCTAssertEqual(UtilityOpcode.jrClock.rawValue, 0x01)
+        XCTAssertEqual(UtilityOpcode.jrTimestamp.rawValue, 0x02)
+    }
+
+    func testInitFromRaw() {
+        XCTAssertEqual(UtilityOpcode(rawValue: 0x00), .noop)
+        XCTAssertEqual(UtilityOpcode(rawValue: 0x01), .jrClock)
+        XCTAssertEqual(UtilityOpcode(rawValue: 0x02), .jrTimestamp)
+        XCTAssertNil(UtilityOpcode(rawValue: 0x03))
     }
 }


### PR DESCRIPTION
## Summary
- add roundtrip and error tests for Uint4/7/14 wrappers
- cover Utility and Stream opcodes plus DataMessageKind and UMP packets
- add SwiftCheck fuzz tests for Uint4 and Uint14

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_b_689cc448cbfc8333bff36a703e87ca8d