### PR TITLE
Integrate schema descriptions into Swift doc comments

### DIFF
--- a/Scripts/inject_schema_docs.py
+++ b/Scripts/inject_schema_docs.py
@@ -1,0 +1,36 @@
+import json
+import pathlib
+import re
+
+SCHEMA_PATH = pathlib.Path('midi2.full.closed.schema.json')
+SOURCES_DIR = pathlib.Path('Sources')
+
+schema = json.loads(SCHEMA_PATH.read_text())
+defs = schema.get('$defs', {})
+
+# Build mapping from swift type name to description
+mapping = {}
+for key, val in defs.items():
+    desc = val.get('description')
+    if not desc:
+        continue
+    swift_name = key.split('.')[-1]
+    mapping[swift_name] = desc
+
+for swift_name, desc in mapping.items():
+    # Search for Swift source files matching the type name
+    for file in SOURCES_DIR.rglob(f'{swift_name}.swift'):
+        text = file.read_text()
+        # regex to find struct or enum definition
+        pattern = re.compile(r'(\n|\A)(?P<indent>\s*)(?:///.*\n)*(?P<keyword>public\s+(struct|enum)\s+' + re.escape(swift_name) + r'\b)', re.MULTILINE)
+        m = pattern.search(text)
+        if not m:
+            continue
+        indent = m.group('indent')
+        keyword = m.group('keyword')
+        # Build doc comment
+        doc = '/// ' + desc.replace('\n', '\n' + indent + '/// ')
+        replacement = '\n' + indent + doc + '\n' + indent + keyword
+        new_text = pattern.sub(replacement, text, count=1)
+        file.write_text(new_text)
+        print(f'Updated {file}')

--- a/Sources/MIDI2/ChannelVoice/ControlChange.swift
+++ b/Sources/MIDI2/ChannelVoice/ControlChange.swift
@@ -1,4 +1,4 @@
-/// Status 0xB (Control Change) message.
+/// Status 0xB (CC).
 public struct ControlChange: Equatable {
     public let group: Uint4
     public let channel: Uint4

--- a/Sources/MIDI2/ChannelVoice/NoteOff.swift
+++ b/Sources/MIDI2/ChannelVoice/NoteOff.swift
@@ -1,4 +1,4 @@
-/// Status 0x8 (Note Off) message.
+/// Status 0x8 (Note Off).
 public struct NoteOff: Equatable {
     public let group: Uint4
     public let channel: Uint4

--- a/Sources/MIDI2/ChannelVoice/PitchBend.swift
+++ b/Sources/MIDI2/ChannelVoice/PitchBend.swift
@@ -1,4 +1,4 @@
-/// Status 0xE (Pitch Bend) message.
+/// Status 0xE (Pitch Bend).
 public struct PitchBend: Equatable {
     public let group: Uint4
     public let channel: Uint4

--- a/Sources/MIDI2/ChannelVoice/PolyPressure.swift
+++ b/Sources/MIDI2/ChannelVoice/PolyPressure.swift
@@ -1,4 +1,4 @@
-/// Status 0xA (Polyphonic Key Pressure) message.
+/// Status 0xA (Polyphonic Key Pressure).
 public struct PolyPressure: Equatable {
     public let group: Uint4
     public let channel: Uint4

--- a/Sources/MIDI2/ChannelVoice/ProgramChange.swift
+++ b/Sources/MIDI2/ChannelVoice/ProgramChange.swift
@@ -1,4 +1,4 @@
-/// Status 0xC (Program Change) message.
+/// Status 0xC (Program Change).
 public struct ProgramChange: Equatable {
     public let group: Uint4
     public let channel: Uint4

--- a/Sources/MIDI2/Midi2ChannelVoiceBody.swift
+++ b/Sources/MIDI2/Midi2ChannelVoiceBody.swift
@@ -1,7 +1,4 @@
-/// Common 64-bit layout for MIDI 2.0 Channel Voice messages.
-///
-/// Provides access to the generic fields shared by all channel voice messages
-/// and convenience decoding into strongly typed variants.
+/// Only fields relevant to the specific status are present.
 public struct Midi2ChannelVoiceBody: Equatable {
     public let group: Uint4
     public let status: UInt8

--- a/Sources/MIDI2/StreamBody.swift
+++ b/Sources/MIDI2/StreamBody.swift
@@ -1,8 +1,4 @@
-/// Body for UMP message type ``0xF`` Stream packets.
-///
-/// Stream packets are used during endpoint discovery and configuration.  Each
-/// packet carries an opcode followed by two data bytes whose meaning depends on
-/// the opcode.
+/// Endpoint discovery, protocol selection, and FB info.
 public struct StreamBody: Equatable {
     /// Stream message opcode.
     public var opcode: StreamOpcode

--- a/Sources/MIDI2/SysEx7Body.swift
+++ b/Sources/MIDI2/SysEx7Body.swift
@@ -1,4 +1,4 @@
-/// Sequence of SysEx7 packets representing a complete SysEx7 message.
+/// 7-bit clean stream framed in 32-bit UMP words (up to 6 bytes per word).
 public struct SysEx7Body: Equatable {
     /// Ordered packets forming the SysEx7 transfer.
     public var packets: [SysEx7Packet]

--- a/Sources/MIDI2/SystemCommonRealtimeBody.swift
+++ b/Sources/MIDI2/SystemCommonRealtimeBody.swift
@@ -1,7 +1,4 @@
-/// Body for UMP message type ``0x1`` carrying System Common or Real‑Time data.
-///
-/// The message header provides the group nibble while this body models the
-/// status byte and the two following data bytes.
+/// UMP 0x1 System Common & Real-Time.
 public struct SystemCommonRealtimeBody: Equatable {
     /// MIDI system status byte.
     public var status: SystemStatus

--- a/Sources/MIDI2/SystemStatus.swift
+++ b/Sources/MIDI2/SystemStatus.swift
@@ -1,9 +1,4 @@
-/// All status bytes that are considered valid for UMP System Common and
-/// System Real‑Time messages.
-///
-/// The values correspond directly to the 8‑bit status byte found in the
-/// second byte of a message type ``0x1`` UMP packet.  Both System Common and
-/// System Real‑Time messages share this enumeration.
+/// MIDI System Common/Real-Time per UMP.
 public enum SystemStatus: UInt8, Equatable {
     // System Common
     case mtcQuarterFrame     = 0xF1

--- a/Sources/MIDI2/UmpHeader128.swift
+++ b/Sources/MIDI2/UmpHeader128.swift
@@ -1,8 +1,4 @@
-/// 128-bit UMP header for Data (SysEx8/MDS) and Flex Data messages.
-///
-/// The first word encodes the message type (``0x5`` for SysEx8 or ``0xD`` for
-/// Flex Data), an optional group, an 8-bit status field and two data bytes that
-/// commonly represent byte counts.
+/// 128-bit UMP header for Data (SysEx8/MDS) and Flex Data.
 public struct UmpHeader128: Equatable {
     /// Raw 32-bit word representing the header.
     public let word: UInt32

--- a/Sources/MIDI2/UmpHeader32.swift
+++ b/Sources/MIDI2/UmpHeader32.swift
@@ -1,9 +1,4 @@
-/// Common 32-bit UMP header (messageType + group + status + two data bytes).
-///
-/// The first 32-bit word of many UMP packet types share this layout.  The
-/// leading nibble is the message type, followed by a 4-bit group.  The next
-/// byte is the status field and the final two bytes are typically payload
-/// data or counts depending on the message type.
+/// Common 32-bit UMP header (messageType + optional group).
 public struct UmpHeader32: Equatable {
     /// Raw 32-bit word representing the header.
     public let word: UInt32

--- a/Sources/MIDI2/UmpHeader64.swift
+++ b/Sources/MIDI2/UmpHeader64.swift
@@ -1,8 +1,4 @@
-/// 64-bit UMP header for MIDI 2.0 Channel Voice messages.
-///
-/// The first word encodes message type ``0x4``, a group nibble, status nibble,
-/// channel, and two data bytes.  The remaining word contains additional payload
-/// data.
+/// 64-bit UMP header for MIDI 2.0 Channel Voice.
 public struct UmpHeader64: Equatable {
     /// Raw 32-bit word representing the header.
     public let word: UInt32

--- a/Sources/MIDI2/UtilityBody.swift
+++ b/Sources/MIDI2/UtilityBody.swift
@@ -1,8 +1,4 @@
-/// Body payload for UMP message type ``0x0`` Utility packets.
-///
-/// Utility packets are _groupless_ and contain a single opcode in the status
-/// byte followed by two data bytes that are interpreted according to the
-/// opcode.  The body therefore stores the opcode and the raw 16‑bit value.
+/// UMP Type 0x0 Utility messages (groupless).
 public struct UtilityBody: Equatable {
     /// The opcode describing the utility message.
     public var opcode: UtilityOpcode

--- a/Sources/MIDI2/UtilityOpcode.swift
+++ b/Sources/MIDI2/UtilityOpcode.swift
@@ -1,9 +1,4 @@
-/// Opcode values for UMP Utility messages.
-///
-/// These opcodes occupy the status byte of a message type ``0x0`` packet and
-/// determine how the remaining 16 bits of the packet should be interpreted.
-/// The library only defines the three opcodes currently specified by the
-/// standard.
+/// 0=NOOP,1=JR Clock,2=JR Timestamp
 public enum UtilityOpcode: UInt8, Equatable {
     /// No operation.  Used for padding.
     case noop        = 0x00


### PR DESCRIPTION
## Summary
- derive Swift doc comments from `midi2.full.closed.schema.json`
- add helper script to inject descriptions automatically

## Testing
- `swift test`
- `swiftc -I .build/debug/Modules -L .build/debug -lMIDI2 -typecheck Examples/BasicUsage.playground/Contents.swift`
- `swiftc -I .build/debug/Modules -L .build/debug -lMIDI2 -typecheck Examples/SysEx7.playground/Contents.swift`


------
https://chatgpt.com/codex/tasks/task_b_689cc9e6d6b083339a032b91a45539bb