### PR TITLE
Add UMP message type enum with tests

### DIFF
--- a/Sources/MIDI2/UmpMessageType.swift
+++ b/Sources/MIDI2/UmpMessageType.swift
@@ -1,3 +1,34 @@
 /// UMP Message Type nibble: 0=Utility,1=System,2=MIDI1 Ch Voice,3=SysEx7,4=MIDI2 Ch Voice,5=SysEx8/MDS,13=Flex,15=Stream.
-public struct UmpMessageType {
+public enum UmpMessageType: UInt8, Equatable {
+    /// Utility messages (type `0x0`).
+    case utility            = 0x0
+    /// System messages (type `0x1`).
+    case system             = 0x1
+    /// MIDI 1.0 Channel Voice messages (type `0x2`).
+    case midi1ChannelVoice  = 0x2
+    /// SysEx 7-bit messages (type `0x3`).
+    case sysEx7             = 0x3
+    /// MIDI 2.0 Channel Voice messages (type `0x4`).
+    case midi2ChannelVoice  = 0x4
+    /// Data messages such as SysEx8 and MDS (type `0x5`).
+    case data               = 0x5
+    /// Flex Data messages (type `0xD`).
+    case flex               = 0xD
+    /// Stream messages (type `0xF`).
+    case stream             = 0xF
+
+    /// Initialise from a raw nibble value.
+    public init?(_ raw: UInt8) {
+        self.init(rawValue: raw)
+    }
+
+    /// Convenience flag indicating if this is any kind of channel voice message.
+    public var isChannel: Bool {
+        switch self {
+        case .midi1ChannelVoice, .midi2ChannelVoice:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Tests/MIDI2Tests/UmpMessageTypeTests.swift
+++ b/Tests/MIDI2Tests/UmpMessageTypeTests.swift
@@ -2,7 +2,23 @@ import XCTest
 @testable import MIDI2
 
 final class UmpMessageTypeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test UmpMessageType
+    /// Verify that known raw nibbles map to the expected enum cases.
+    func testRawValueMapping() {
+        XCTAssertEqual(UmpMessageType(rawValue: 0x0), .utility)
+        XCTAssertEqual(UmpMessageType(rawValue: 0x1), .system)
+        XCTAssertEqual(UmpMessageType(rawValue: 0x2), .midi1ChannelVoice)
+        XCTAssertEqual(UmpMessageType(rawValue: 0x3), .sysEx7)
+        XCTAssertEqual(UmpMessageType(rawValue: 0x4), .midi2ChannelVoice)
+        XCTAssertEqual(UmpMessageType(rawValue: 0x5), .data)
+        XCTAssertEqual(UmpMessageType(rawValue: 0xD), .flex)
+        XCTAssertEqual(UmpMessageType(rawValue: 0xF), .stream)
+    }
+
+    /// Ensure invalid nibble values fail to initialise.
+    func testInvalidNibbles() {
+        let invalid: [UInt8] = [0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xE]
+        for raw in invalid {
+            XCTAssertNil(UmpMessageType(rawValue: raw), "Expected nil for 0x\(String(raw, radix: 16))")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement `UmpMessageType` enum with cases, initializer, and convenience `isChannel`
- add unit tests validating mapping and invalid nibble handling

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689ccd4c4bf88333af96c26447fea11b