### PR TITLE
Implement Mixed Data Set data message support

### DIFF
--- a/Sources/MIDI2/Data/MixedDataSet.swift
+++ b/Sources/MIDI2/Data/MixedDataSet.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Helpers for streaming Mixed Data Set data in UMP packets.
+public enum MixedDataSet {
+    /// Representation of a Mixed Data Set message chunk.
+    public struct Chunk: Equatable {
+        public let mdsID: Uint4
+        public let numberOfChunks: UInt16
+        public let chunkNumber: UInt16
+        public let manufacturerID: UInt16
+        public let deviceID: UInt16
+        public let subID1: UInt16
+        public let subID2: UInt16
+        public let data: [UInt8]
+
+        public init(mdsID: Uint4,
+                    numberOfChunks: UInt16,
+                    chunkNumber: UInt16,
+                    manufacturerID: UInt16,
+                    deviceID: UInt16,
+                    subID1: UInt16,
+                    subID2: UInt16,
+                    data: [UInt8]) {
+            self.mdsID = mdsID
+            self.numberOfChunks = numberOfChunks
+            self.chunkNumber = chunkNumber
+            self.manufacturerID = manufacturerID
+            self.deviceID = deviceID
+            self.subID1 = subID1
+            self.subID2 = subID2
+            self.data = data
+        }
+    }
+
+    /// Errors thrown by the Mixed Data Set streaming helpers.
+    public enum StreamError: Error {
+        case payloadTooLong
+        case invalidPacketSequence
+        case wrongMessageType
+    }
+
+    private static let maxChunkPayload = 14
+    private static let maxValidBytes = 0xFFFF
+
+    /// Fragment a Mixed Data Set chunk into UMP packets.
+    /// - Parameters:
+    ///   - chunk: The chunk metadata and payload.
+    ///   - group: UMP group (0-15).
+    /// - Returns: Array of 16 byte UMP packets.
+    public static func fragment(chunk: Chunk, group: UInt8 = 0) throws -> [[UInt8]] {
+        let validBytes = 16 + chunk.data.count
+        guard validBytes <= maxValidBytes else { throw StreamError.payloadTooLong }
+
+        let mtg = 0x50 | (group & 0x0F)
+        let statusId = (0x8 << 4) | chunk.mdsID.rawValue
+
+        var header: [UInt8] = [mtg, statusId]
+        header.append(UInt8((validBytes >> 8) & 0xFF))
+        header.append(UInt8(validBytes & 0xFF))
+        header.append(UInt8((chunk.numberOfChunks >> 8) & 0xFF))
+        header.append(UInt8(chunk.numberOfChunks & 0xFF))
+        header.append(UInt8((chunk.chunkNumber >> 8) & 0xFF))
+        header.append(UInt8(chunk.chunkNumber & 0xFF))
+        header.append(UInt8((chunk.manufacturerID >> 8) & 0xFF))
+        header.append(UInt8(chunk.manufacturerID & 0xFF))
+        header.append(UInt8((chunk.deviceID >> 8) & 0xFF))
+        header.append(UInt8(chunk.deviceID & 0xFF))
+        header.append(UInt8((chunk.subID1 >> 8) & 0xFF))
+        header.append(UInt8(chunk.subID1 & 0xFF))
+        header.append(UInt8((chunk.subID2 >> 8) & 0xFF))
+        header.append(UInt8(chunk.subID2 & 0xFF))
+
+        var packets: [[UInt8]] = [header]
+
+        var index = 0
+        while index < chunk.data.count {
+            let remaining = chunk.data.count - index
+            let size = min(maxChunkPayload, remaining)
+            let chunkData = Array(chunk.data[index..<index+size])
+            var packet: [UInt8] = [mtg, (0x9 << 4) | chunk.mdsID.rawValue]
+            packet.append(contentsOf: chunkData)
+            if size < maxChunkPayload {
+                packet.append(contentsOf: Array(repeating: 0, count: maxChunkPayload - size))
+            }
+            packets.append(packet)
+            index += size
+        }
+
+        return packets
+    }
+
+    /// Reassemble a Mixed Data Set chunk from UMP packets.
+    /// - Parameter packets: Array of 16 byte UMP packets.
+    /// - Returns: Chunk metadata and payload.
+    public static func reassemble(_ packets: [[UInt8]]) throws -> Chunk {
+        guard !packets.isEmpty else { throw StreamError.invalidPacketSequence }
+        let header = packets[0]
+        guard header.count == 16 else { throw StreamError.invalidPacketSequence }
+        let mt = header[0] >> 4
+        guard mt == 0x5 else { throw StreamError.wrongMessageType }
+        let status = header[1] >> 4
+        guard status == 0x8 else { throw StreamError.invalidPacketSequence }
+        let mdsIdRaw = header[1] & 0x0F
+        guard let mdsID = Uint4(mdsIdRaw) else { throw StreamError.invalidPacketSequence }
+        let validBytes = Int(header[2]) << 8 | Int(header[3])
+        guard validBytes >= 16 else { throw StreamError.invalidPacketSequence }
+        let numberOfChunks = UInt16(header[4]) << 8 | UInt16(header[5])
+        let chunkNumber = UInt16(header[6]) << 8 | UInt16(header[7])
+        let manufacturerID = UInt16(header[8]) << 8 | UInt16(header[9])
+        let deviceID = UInt16(header[10]) << 8 | UInt16(header[11])
+        let subID1 = UInt16(header[12]) << 8 | UInt16(header[13])
+        let subID2 = UInt16(header[14]) << 8 | UInt16(header[15])
+
+        let expectedPayloadBytes = validBytes - 16
+        let requiredPayloadPackets = (expectedPayloadBytes + maxChunkPayload - 1) / maxChunkPayload
+        guard packets.count == 1 + requiredPayloadPackets else { throw StreamError.invalidPacketSequence }
+
+        var data: [UInt8] = []
+        for packet in packets.dropFirst() {
+            guard packet.count == 16 else { throw StreamError.invalidPacketSequence }
+            let mt2 = packet[0] >> 4
+            guard mt2 == 0x5 else { throw StreamError.wrongMessageType }
+            let status2 = packet[1] >> 4
+            let mdsId2 = packet[1] & 0x0F
+            guard status2 == 0x9, mdsId2 == mdsIdRaw else { throw StreamError.invalidPacketSequence }
+            data.append(contentsOf: packet[2..<16])
+        }
+        guard data.count >= expectedPayloadBytes else { throw StreamError.invalidPacketSequence }
+        data = Array(data.prefix(expectedPayloadBytes))
+
+        return Chunk(mdsID: mdsID,
+                     numberOfChunks: numberOfChunks,
+                     chunkNumber: chunkNumber,
+                     manufacturerID: manufacturerID,
+                     deviceID: deviceID,
+                     subID1: subID1,
+                     subID2: subID2,
+                     data: data)
+    }
+}
+

--- a/Sources/MIDI2/DataMessageBody.swift
+++ b/Sources/MIDI2/DataMessageBody.swift
@@ -2,13 +2,12 @@ import Foundation
 
 /// Body payload for UMP Data Messages (message type ``0x5``).
 ///
-/// This implementation currently supports SysEx8 transfers.  Mixed Data Set
-/// transfers are modelled by the `mds` case but are not yet encoded.
+/// This implementation currently supports SysEx8 and Mixed Data Set transfers.
 public enum DataMessageBody: Equatable {
     /// SysEx8 payload consisting of manufacturer ID and data bytes.
     case sysex8(manufacturerID: [UInt8], data: [UInt8])
-    /// Mixed Data Set payload (not fully implemented).
-    case mds
+    /// Mixed Data Set chunk consisting of header fields and payload.
+    case mds(MixedDataSet.Chunk)
 
     /// Kind of data message.
     public var kind: DataMessageKind {
@@ -25,9 +24,9 @@ public enum DataMessageBody: Equatable {
         case let .sysex8(mfr, data):
             let packets = try SysEx8.fragment(manufacturerID: mfr, payload: data, group: group.rawValue)
             return packets.compactMap { UmpPacket128(rawBytes: $0) }
-        case .mds:
-            // Encoding for MDS is not implemented.
-            return []
+        case let .mds(chunk):
+            let packets = try MixedDataSet.fragment(chunk: chunk, group: group.rawValue)
+            return packets.compactMap { UmpPacket128(rawBytes: $0) }
         }
     }
 
@@ -37,6 +36,14 @@ public enum DataMessageBody: Equatable {
         let raw = packets.map { $0.rawBytes }
         guard let (mfr, payload) = try? SysEx8.reassemble(raw) else { return nil }
         self = .sysex8(manufacturerID: mfr, data: payload)
+    }
+
+    /// Decodes a Mixed Data Set body from an array of ``UmpPacket128`` packets.
+    /// Returns `nil` if the packets do not form a valid Mixed Data Set chunk.
+    public init?(mdsPackets packets: [UmpPacket128]) {
+        let raw = packets.map { $0.rawBytes }
+        guard let chunk = try? MixedDataSet.reassemble(raw) else { return nil }
+        self = .mds(chunk)
     }
 }
 

--- a/Tests/MIDI2Tests/DataMessageBodyTests.swift
+++ b/Tests/MIDI2Tests/DataMessageBodyTests.swift
@@ -8,4 +8,64 @@ final class DataMessageBodyTests: XCTestCase {
         let decoded = DataMessageBody(sysex8Packets: packets)
         XCTAssertEqual(decoded, body)
     }
+
+    func testRoundTripMDS() throws {
+        let payload = (1...20).map { UInt8($0) }
+        let chunk = MixedDataSet.Chunk(
+            mdsID: Uint4(0x2)!,
+            numberOfChunks: 1,
+            chunkNumber: 1,
+            manufacturerID: 0x1234,
+            deviceID: 0x5678,
+            subID1: 0x9ABC,
+            subID2: 0xDEF0,
+            data: payload
+        )
+        let body = DataMessageBody.mds(chunk)
+        let packets = try body.umpPackets(group: Uint4(0x0)!)
+        let decoded = DataMessageBody(mdsPackets: packets)
+        XCTAssertEqual(decoded, body)
+    }
+
+    func testMDSInvalidMismatchedID() throws {
+        let chunk = MixedDataSet.Chunk(
+            mdsID: Uint4(0x1)!,
+            numberOfChunks: 1,
+            chunkNumber: 1,
+            manufacturerID: 0x0001,
+            deviceID: 0x0002,
+            subID1: 0x0003,
+            subID2: 0x0004,
+            data: [0x10, 0x11, 0x12]
+        )
+        let body = DataMessageBody.mds(chunk)
+        var packets = try body.umpPackets(group: Uint4(0x0)!)
+        // tamper with MDS ID in payload packet
+        if packets.count > 1 {
+            var raw = packets[1].rawBytes
+            raw[1] = (raw[1] & 0xF0) | 0x0
+            packets[1] = UmpPacket128(rawBytes: raw)!
+        }
+        let decoded = DataMessageBody(mdsPackets: packets)
+        XCTAssertNil(decoded)
+    }
+
+    func testMDSInvalidMissingData() throws {
+        let chunk = MixedDataSet.Chunk(
+            mdsID: Uint4(0x3)!,
+            numberOfChunks: 1,
+            chunkNumber: 1,
+            manufacturerID: 0x0001,
+            deviceID: 0x0002,
+            subID1: 0x0003,
+            subID2: 0x0004,
+            data: [0x20, 0x21]
+        )
+        let body = DataMessageBody.mds(chunk)
+        var packets = try body.umpPackets(group: Uint4(0x0)!)
+        // remove payload packet so data is missing
+        packets.removeLast()
+        let decoded = DataMessageBody(mdsPackets: packets)
+        XCTAssertNil(decoded)
+    }
 }

--- a/Tests/MIDI2Tests/DataMessageKindTests.swift
+++ b/Tests/MIDI2Tests/DataMessageKindTests.swift
@@ -6,7 +6,17 @@ final class DataMessageKindTests: XCTestCase {
         let body = DataMessageBody.sysex8(manufacturerID: [0x7D], data: [0x01])
         XCTAssertEqual(body.kind, .sysex8)
 
-        let mds = DataMessageBody.mds
+        let chunk = MixedDataSet.Chunk(
+            mdsID: Uint4(0x0)!,
+            numberOfChunks: 1,
+            chunkNumber: 1,
+            manufacturerID: 0,
+            deviceID: 0,
+            subID1: 0,
+            subID2: 0,
+            data: []
+        )
+        let mds = DataMessageBody.mds(chunk)
         XCTAssertEqual(mds.kind, .mds)
     }
 }


### PR DESCRIPTION
## Summary
- add MixedDataSet helpers for chunk fragmentation and reassembly
- support `.mds` in `DataMessageBody` including encoding/decoding
- add round-trip and validation tests for Mixed Data Set messages

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689cceee2a088333bcb868f0aca72617