### PR TITLE
Add additional Flex data message types

### DIFF
--- a/Sources/MIDI2/FlexDataBody.swift
+++ b/Sources/MIDI2/FlexDataBody.swift
@@ -1,17 +1,25 @@
 /// Body payload for Flex Data messages.
 public enum FlexDataBody: Equatable {
     case tempo(FlexDataTempo)
+    case timeSignature(FlexTimeSignature)
+    case metronome(FlexMetronome)
+    case keySignature(FlexKeySignature)
     case chordName(FlexChordName)
     case text(FlexText)
     case lyric(FlexLyric)
+    case ruby(FlexRuby)
 
     /// Encodes the body into a single ``Ump128`` packet.
     public func encode() -> Ump128 {
         switch self {
         case .tempo(let t): return t.encode()
+        case .timeSignature(let ts): return ts.encode()
+        case .metronome(let m): return m.encode()
+        case .keySignature(let k): return k.encode()
         case .chordName(let c): return c.encode()
         case .text(let t): return t.encode()
         case .lyric(let l): return l.encode()
+        case .ruby(let r): return r.encode()
         }
     }
 
@@ -23,6 +31,15 @@ public enum FlexDataBody: Equatable {
         case (0x10, 0x01):
             guard let t = FlexDataTempo.decode(packet) else { return nil }
             self = .tempo(t)
+        case (0x10, 0x02):
+            guard let ts = FlexTimeSignature.decode(packet) else { return nil }
+            self = .timeSignature(ts)
+        case (0x10, 0x03):
+            guard let m = FlexMetronome.decode(packet) else { return nil }
+            self = .metronome(m)
+        case (0x10, 0x04):
+            guard let k = FlexKeySignature.decode(packet) else { return nil }
+            self = .keySignature(k)
         case (0x10, 0x05):
             guard let c = FlexChordName.decode(packet) else { return nil }
             self = .chordName(c)
@@ -32,6 +49,9 @@ public enum FlexDataBody: Equatable {
         case (0x11, 0x02):
             guard let l = FlexLyric.decode(packet) else { return nil }
             self = .lyric(l)
+        case (0x11, 0x03):
+            guard let r = FlexRuby.decode(packet) else { return nil }
+            self = .ruby(r)
         default:
             return nil
         }

--- a/Sources/MIDI2/FlexKeySignature.swift
+++ b/Sources/MIDI2/FlexKeySignature.swift
@@ -1,3 +1,97 @@
-/// Flex: Set Key Signature (e.g., 'C', 'Gm').
-public struct FlexKeySignature {
+/// Flex: Set Key Signature (e.g., "C", "Gm").
+public struct FlexKeySignature: Equatable {
+    /// Address scope for the key signature.
+    public enum Address: Equatable {
+        case group(Uint4)
+        case channel(group: Uint4, channel: Uint4)
+    }
+
+    /// Address indicating group or channel scope.
+    public var address: Address
+
+    /// Key signature text.
+    public var key: String
+
+    /// Creates a key signature message.
+    public init(address: Address, key: String) {
+        self.address = address
+        self.key = key
+    }
+
+    private static let statusClass: UInt8 = 0x10
+    private static let status: UInt8 = 0x04
+
+    /// Encodes the message into a 128-bit UMP packet.
+    public func encode() -> Ump128 {
+        let (group, addrByte): (UInt8, UInt8)
+        switch address {
+        case .group(let g):
+            group = g.rawValue
+            addrByte = 0x00
+        case .channel(let g, let c):
+            group = g.rawValue
+            addrByte = 0x10 | c.rawValue
+        }
+
+        var bytes = Array(key.utf8.prefix(12))
+        bytes += Array(repeating: 0, count: 12 - bytes.count)
+        let word1 = UInt32(bytes[0]) << 24 |
+                    UInt32(bytes[1]) << 16 |
+                    UInt32(bytes[2]) << 8  |
+                    UInt32(bytes[3])
+        let word2 = UInt32(bytes[4]) << 24 |
+                    UInt32(bytes[5]) << 16 |
+                    UInt32(bytes[6]) << 8  |
+                    UInt32(bytes[7])
+        let word3 = UInt32(bytes[8]) << 24 |
+                    UInt32(bytes[9]) << 16 |
+                    UInt32(bytes[10]) << 8 |
+                    UInt32(bytes[11])
+
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8 |
+                    UInt32(addrByte)
+
+        return Ump128(word0: word0, word1: word1, word2: word2, word3: word3)!
+    }
+
+    /// Decodes a key signature message from a UMP packet.
+    public static func decode(_ packet: Ump128) -> FlexKeySignature? {
+        guard packet.messageType == 0xD else { return nil }
+        let sc = UInt8((packet.word0 >> 16) & 0xFF)
+        let st = UInt8((packet.word0 >> 8) & 0xFF)
+        guard sc == statusClass, st == status else { return nil }
+
+        guard let group = Uint4(UInt8((packet.word0 >> 24) & 0xF)) else { return nil }
+        let addrByte = UInt8(packet.word0 & 0xFF)
+        let address: Address
+        if addrByte & 0x10 != 0 {
+            guard let ch = Uint4(addrByte & 0xF) else { return nil }
+            address = .channel(group: group, channel: ch)
+        } else {
+            address = .group(group)
+        }
+
+        let bytes: [UInt8] = [
+            UInt8((packet.word1 >> 24) & 0xFF),
+            UInt8((packet.word1 >> 16) & 0xFF),
+            UInt8((packet.word1 >> 8) & 0xFF),
+            UInt8(packet.word1 & 0xFF),
+            UInt8((packet.word2 >> 24) & 0xFF),
+            UInt8((packet.word2 >> 16) & 0xFF),
+            UInt8((packet.word2 >> 8) & 0xFF),
+            UInt8(packet.word2 & 0xFF),
+            UInt8((packet.word3 >> 24) & 0xFF),
+            UInt8((packet.word3 >> 16) & 0xFF),
+            UInt8((packet.word3 >> 8) & 0xFF),
+            UInt8(packet.word3 & 0xFF)
+        ]
+
+        let strBytes = bytes.prefix { $0 != 0 }
+        let key = String(bytes: strBytes, encoding: .utf8) ?? ""
+        return FlexKeySignature(address: address, key: key)
+    }
 }
+

--- a/Sources/MIDI2/FlexMetronome.swift
+++ b/Sources/MIDI2/FlexMetronome.swift
@@ -1,3 +1,109 @@
 /// Flex: Set Metronome parameters.
-public struct FlexMetronome {
+public struct FlexMetronome: Equatable {
+    /// Address scope for the metronome message.
+    public enum Address: Equatable {
+        case group(Uint4)
+        case channel(group: Uint4, channel: Uint4)
+    }
+
+    /// Address indicating group or channel scope.
+    public var address: Address
+
+    /// Number of metronome clicks per beat.
+    public var clicksPerBeat: UInt16
+
+    /// Accent pattern string.
+    public var accentPattern: String
+
+    /// Creates a metronome message.
+    public init(address: Address, clicksPerBeat: UInt16, accentPattern: String) {
+        precondition(clicksPerBeat >= 1, "clicksPerBeat must be at least 1")
+        self.address = address
+        self.clicksPerBeat = clicksPerBeat
+        self.accentPattern = accentPattern
+    }
+
+    private static let statusClass: UInt8 = 0x10
+    private static let status: UInt8 = 0x03
+
+    /// Encodes the message into a 128-bit UMP packet.
+    public func encode() -> Ump128 {
+        let (group, addrByte): (UInt8, UInt8)
+        switch address {
+        case .group(let g):
+            group = g.rawValue
+            addrByte = 0x00
+        case .channel(let g, let c):
+            group = g.rawValue
+            addrByte = 0x10 | c.rawValue
+        }
+
+        var patternBytes = Array(accentPattern.utf8.prefix(10))
+        patternBytes += Array(repeating: 0, count: 10 - patternBytes.count)
+        let bytes: [UInt8] = [
+            UInt8((clicksPerBeat >> 8) & 0xFF),
+            UInt8(clicksPerBeat & 0xFF)
+        ] + patternBytes
+
+        let word1 = UInt32(bytes[0]) << 24 |
+                    UInt32(bytes[1]) << 16 |
+                    UInt32(bytes[2]) << 8  |
+                    UInt32(bytes[3])
+        let word2 = UInt32(bytes[4]) << 24 |
+                    UInt32(bytes[5]) << 16 |
+                    UInt32(bytes[6]) << 8  |
+                    UInt32(bytes[7])
+        let word3 = UInt32(bytes[8]) << 24 |
+                    UInt32(bytes[9]) << 16 |
+                    UInt32(bytes[10]) << 8 |
+                    UInt32(bytes[11])
+
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8 |
+                    UInt32(addrByte)
+
+        return Ump128(word0: word0, word1: word1, word2: word2, word3: word3)!
+    }
+
+    /// Decodes a metronome message from a UMP packet.
+    public static func decode(_ packet: Ump128) -> FlexMetronome? {
+        guard packet.messageType == 0xD else { return nil }
+        let sc = UInt8((packet.word0 >> 16) & 0xFF)
+        let st = UInt8((packet.word0 >> 8) & 0xFF)
+        guard sc == statusClass, st == status else { return nil }
+
+        guard let group = Uint4(UInt8((packet.word0 >> 24) & 0xF)) else { return nil }
+        let addrByte = UInt8(packet.word0 & 0xFF)
+        let address: Address
+        if addrByte & 0x10 != 0 {
+            guard let ch = Uint4(addrByte & 0xF) else { return nil }
+            address = .channel(group: group, channel: ch)
+        } else {
+            address = .group(group)
+        }
+
+        let bytes: [UInt8] = [
+            UInt8((packet.word1 >> 24) & 0xFF),
+            UInt8((packet.word1 >> 16) & 0xFF),
+            UInt8((packet.word1 >> 8) & 0xFF),
+            UInt8(packet.word1 & 0xFF),
+            UInt8((packet.word2 >> 24) & 0xFF),
+            UInt8((packet.word2 >> 16) & 0xFF),
+            UInt8((packet.word2 >> 8) & 0xFF),
+            UInt8(packet.word2 & 0xFF),
+            UInt8((packet.word3 >> 24) & 0xFF),
+            UInt8((packet.word3 >> 16) & 0xFF),
+            UInt8((packet.word3 >> 8) & 0xFF),
+            UInt8(packet.word3 & 0xFF)
+        ]
+
+        let clicks = UInt16(bytes[0]) << 8 | UInt16(bytes[1])
+        guard clicks >= 1 else { return nil }
+        let patternBytes = bytes[2...].prefix { $0 != 0 }
+        let pattern = String(bytes: patternBytes, encoding: .utf8) ?? ""
+        return FlexMetronome(address: address, clicksPerBeat: clicks, accentPattern: pattern)
+    }
 }
+

--- a/Sources/MIDI2/FlexRuby.swift
+++ b/Sources/MIDI2/FlexRuby.swift
@@ -1,3 +1,97 @@
 /// Flex Ruby (furigana).
-public struct FlexRuby {
+public struct FlexRuby: Equatable {
+    /// Address scope for the ruby text.
+    public enum Address: Equatable {
+        case group(Uint4)
+        case channel(group: Uint4, channel: Uint4)
+    }
+
+    /// Address indicating group or channel scope.
+    public var address: Address
+
+    /// Ruby text payload.
+    public var ruby: String
+
+    /// Creates a ruby message.
+    public init(address: Address, ruby: String) {
+        self.address = address
+        self.ruby = ruby
+    }
+
+    private static let statusClass: UInt8 = 0x11
+    private static let status: UInt8 = 0x03
+
+    /// Encodes the message into a 128-bit UMP packet.
+    public func encode() -> Ump128 {
+        let (group, addrByte): (UInt8, UInt8)
+        switch address {
+        case .group(let g):
+            group = g.rawValue
+            addrByte = 0x00
+        case .channel(let g, let c):
+            group = g.rawValue
+            addrByte = 0x10 | c.rawValue
+        }
+
+        var bytes = Array(ruby.utf8.prefix(12))
+        bytes += Array(repeating: 0, count: 12 - bytes.count)
+        let word1 = UInt32(bytes[0]) << 24 |
+                    UInt32(bytes[1]) << 16 |
+                    UInt32(bytes[2]) << 8  |
+                    UInt32(bytes[3])
+        let word2 = UInt32(bytes[4]) << 24 |
+                    UInt32(bytes[5]) << 16 |
+                    UInt32(bytes[6]) << 8  |
+                    UInt32(bytes[7])
+        let word3 = UInt32(bytes[8]) << 24 |
+                    UInt32(bytes[9]) << 16 |
+                    UInt32(bytes[10]) << 8 |
+                    UInt32(bytes[11])
+
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8 |
+                    UInt32(addrByte)
+
+        return Ump128(word0: word0, word1: word1, word2: word2, word3: word3)!
+    }
+
+    /// Decodes a ruby message from a UMP packet.
+    public static func decode(_ packet: Ump128) -> FlexRuby? {
+        guard packet.messageType == 0xD else { return nil }
+        let sc = UInt8((packet.word0 >> 16) & 0xFF)
+        let st = UInt8((packet.word0 >> 8) & 0xFF)
+        guard sc == statusClass, st == status else { return nil }
+
+        guard let group = Uint4(UInt8((packet.word0 >> 24) & 0xF)) else { return nil }
+        let addrByte = UInt8(packet.word0 & 0xFF)
+        let address: Address
+        if addrByte & 0x10 != 0 {
+            guard let ch = Uint4(addrByte & 0xF) else { return nil }
+            address = .channel(group: group, channel: ch)
+        } else {
+            address = .group(group)
+        }
+
+        let bytes: [UInt8] = [
+            UInt8((packet.word1 >> 24) & 0xFF),
+            UInt8((packet.word1 >> 16) & 0xFF),
+            UInt8((packet.word1 >> 8) & 0xFF),
+            UInt8(packet.word1 & 0xFF),
+            UInt8((packet.word2 >> 24) & 0xFF),
+            UInt8((packet.word2 >> 16) & 0xFF),
+            UInt8((packet.word2 >> 8) & 0xFF),
+            UInt8(packet.word2 & 0xFF),
+            UInt8((packet.word3 >> 24) & 0xFF),
+            UInt8((packet.word3 >> 16) & 0xFF),
+            UInt8((packet.word3 >> 8) & 0xFF),
+            UInt8(packet.word3 & 0xFF)
+        ]
+
+        let strBytes = bytes.prefix { $0 != 0 }
+        let ruby = String(bytes: strBytes, encoding: .utf8) ?? ""
+        return FlexRuby(address: address, ruby: ruby)
+    }
 }
+

--- a/Sources/MIDI2/FlexTimeSignature.swift
+++ b/Sources/MIDI2/FlexTimeSignature.swift
@@ -1,3 +1,76 @@
 /// Flex: Set Time Signature (n / 2^d).
-public struct FlexTimeSignature {
+public struct FlexTimeSignature: Equatable {
+    /// Address scope for the time signature.
+    public enum Address: Equatable {
+        case group(Uint4)
+        case channel(group: Uint4, channel: Uint4)
+    }
+
+    /// Address indicating group or channel scope.
+    public var address: Address
+
+    /// Numerator of the time signature.
+    public var numerator: UInt8
+
+    /// Denominator expressed as power of two (i.e. denominator = 2^d).
+    public var denominatorPow2: UInt8
+
+    /// Creates a time signature message.
+    public init(address: Address, numerator: UInt8, denominatorPow2: UInt8) {
+        precondition(numerator >= 1, "numerator must be at least 1")
+        self.address = address
+        self.numerator = numerator
+        self.denominatorPow2 = denominatorPow2
+    }
+
+    private static let statusClass: UInt8 = 0x10
+    private static let status: UInt8 = 0x02
+
+    /// Encodes the message into a 128-bit UMP packet.
+    public func encode() -> Ump128 {
+        let (group, addrByte): (UInt8, UInt8)
+        switch address {
+        case .group(let g):
+            group = g.rawValue
+            addrByte = 0x00
+        case .channel(let g, let c):
+            group = g.rawValue
+            addrByte = 0x10 | c.rawValue
+        }
+
+        let word1 = UInt32(numerator) << 24 |
+                    UInt32(denominatorPow2) << 16
+
+        let word0 = UInt32(0xD << 28) |
+                    UInt32(group & 0xF) << 24 |
+                    UInt32(Self.statusClass) << 16 |
+                    UInt32(Self.status) << 8 |
+                    UInt32(addrByte)
+
+        return Ump128(word0: word0, word1: word1, word2: 0, word3: 0)!
+    }
+
+    /// Decodes a time signature message from a UMP packet.
+    public static func decode(_ packet: Ump128) -> FlexTimeSignature? {
+        guard packet.messageType == 0xD else { return nil }
+        let sc = UInt8((packet.word0 >> 16) & 0xFF)
+        let st = UInt8((packet.word0 >> 8) & 0xFF)
+        guard sc == statusClass, st == status else { return nil }
+
+        guard let group = Uint4(UInt8((packet.word0 >> 24) & 0xF)) else { return nil }
+        let addrByte = UInt8(packet.word0 & 0xFF)
+        let address: Address
+        if addrByte & 0x10 != 0 {
+            guard let ch = Uint4(addrByte & 0xF) else { return nil }
+            address = .channel(group: group, channel: ch)
+        } else {
+            address = .group(group)
+        }
+
+        let numerator = UInt8((packet.word1 >> 24) & 0xFF)
+        let denom = UInt8((packet.word1 >> 16) & 0xFF)
+        guard numerator >= 1 else { return nil }
+        return FlexTimeSignature(address: address, numerator: numerator, denominatorPow2: denom)
+    }
 }
+

--- a/Tests/MIDI2Tests/FlexKeySignatureTests.swift
+++ b/Tests/MIDI2Tests/FlexKeySignatureTests.swift
@@ -2,7 +2,15 @@ import XCTest
 @testable import MIDI2
 
 final class FlexKeySignatureTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexKeySignature
+    func testRoundTrip() {
+        let addr = FlexKeySignature.Address.channel(group: Uint4(1)!, channel: Uint4(2)!)
+        let msg = FlexKeySignature(address: addr, key: "Gm")
+        let packet = msg.encode()
+        XCTAssertEqual(FlexKeySignature.decode(packet), msg)
+    }
+
+    func testMalformed() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexKeySignature.decode(bad))
     }
 }

--- a/Tests/MIDI2Tests/FlexMetronomeTests.swift
+++ b/Tests/MIDI2Tests/FlexMetronomeTests.swift
@@ -2,7 +2,15 @@ import XCTest
 @testable import MIDI2
 
 final class FlexMetronomeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexMetronome
+    func testRoundTrip() {
+        let addr = FlexMetronome.Address.group(Uint4(3)!)
+        let msg = FlexMetronome(address: addr, clicksPerBeat: 4, accentPattern: "1000")
+        let packet = msg.encode()
+        XCTAssertEqual(FlexMetronome.decode(packet), msg)
+    }
+
+    func testMalformed() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexMetronome.decode(bad))
     }
 }

--- a/Tests/MIDI2Tests/FlexRubyTests.swift
+++ b/Tests/MIDI2Tests/FlexRubyTests.swift
@@ -2,7 +2,15 @@ import XCTest
 @testable import MIDI2
 
 final class FlexRubyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexRuby
+    func testRoundTrip() {
+        let addr = FlexRuby.Address.channel(group: Uint4(0)!, channel: Uint4(1)!)
+        let msg = FlexRuby(address: addr, ruby: "kana")
+        let packet = msg.encode()
+        XCTAssertEqual(FlexRuby.decode(packet), msg)
+    }
+
+    func testMalformed() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexRuby.decode(bad))
     }
 }

--- a/Tests/MIDI2Tests/FlexTimeSignatureTests.swift
+++ b/Tests/MIDI2Tests/FlexTimeSignatureTests.swift
@@ -2,7 +2,15 @@ import XCTest
 @testable import MIDI2
 
 final class FlexTimeSignatureTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test FlexTimeSignature
+    func testRoundTrip() {
+        let addr = FlexTimeSignature.Address.group(Uint4(2)!)
+        let msg = FlexTimeSignature(address: addr, numerator: 3, denominatorPow2: 2)
+        let packet = msg.encode()
+        XCTAssertEqual(FlexTimeSignature.decode(packet), msg)
+    }
+
+    func testMalformed() {
+        let bad = Ump128(word0: 0, word1: 0, word2: 0, word3: 0)!
+        XCTAssertNil(FlexTimeSignature.decode(bad))
     }
 }


### PR DESCRIPTION
## Summary
- implement FlexKeySignature, FlexTimeSignature, FlexMetronome and FlexRuby message structs with encode/decode support
- expand `FlexDataBody` to cover new Flex messages
- add round‑trip and malformed packet tests for the new messages

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689cd1d8824c8333a8dbd94cb11d18a0