### PR TITLE
Implement MIDI2 NRPN/RPN relative messages

### DIFF
--- a/Sources/MIDI2/Midi2NRPNRelative.swift
+++ b/Sources/MIDI2/Midi2NRPNRelative.swift
@@ -1,3 +1,75 @@
 /// Assignable Controller (relative).
-public struct Midi2NRPNRelative {
+///
+/// Encodes a relative delta for a Non-Registered Parameter Number (NRPN)
+/// address. The message is transported as a 64-bit UMP Channel Voice packet
+/// with status nibble ``0x5``. The 14-bit address is represented by a 7-bit
+/// bank and 7-bit index. The delta is a 32-bit two's complement value.
+public struct Midi2NRPNRelative: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let address: Midi2NRPNAddress
+    public let delta: Swift.Int32
+
+    public init(group: Uint4, channel: Uint4, address: Midi2NRPNAddress, delta: Swift.Int32) {
+        self.group = group
+        self.channel = channel
+        self.address = address
+        self.delta = delta
+    }
+
+    /// Encodes the message into a Universal MIDI Packet.
+    public func ump() -> UmpPacket64 {
+        let raw = address.rawValue
+        let bank = UInt8((raw >> 7) & 0x7F)
+        let index = UInt8(raw & 0x7F)
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(0x5) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(bank) << 8 |
+                    UInt32(index)
+        return UmpPacket64(word0: word0, word1: UInt32(bitPattern: delta))
+    }
+
+    /// Failable initializer from a Universal MIDI Packet.
+    public init?(ump: UmpPacket64) {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else { return nil }
+        guard ((ump.word0 >> 20) & 0xF) == 0x5 else { return nil }
+        let bank = UInt8((ump.word0 >> 8) & 0xFF)
+        let index = UInt8(ump.word0 & 0xFF)
+        guard bank < 0x80, index < 0x80 else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        let addrValue = UInt16(bank) << 7 | UInt16(index)
+        guard let addr = Midi2NRPNAddress(rawValue: addrValue) else { return nil }
+        let delta = Swift.Int32(bitPattern: ump.word1)
+        self.init(group: group, channel: channel, address: addr, delta: delta)
+    }
+
+    /// Parses a Universal MIDI Packet into an NRPN relative message.
+    /// Throws ``MIDIError.malformedPacket`` if the packet is not valid.
+    public init(parsingUMP ump: UmpPacket64) throws {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else {
+            throw MIDIError.malformedPacket("expected mt 0x4 but got \(((ump.word0 >> 28) & 0xF))")
+        }
+        guard ((ump.word0 >> 20) & 0xF) == 0x5 else {
+            throw MIDIError.malformedPacket("expected status 0x5 but got \(((ump.word0 >> 20) & 0xF))")
+        }
+        let bankByte = UInt8((ump.word0 >> 8) & 0xFF)
+        let indexByte = UInt8(ump.word0 & 0xFF)
+        guard bankByte < 0x80 else {
+            throw MIDIError.malformedPacket("bank byte msb set")
+        }
+        guard indexByte < 0x80 else {
+            throw MIDIError.malformedPacket("index byte msb set")
+        }
+        let group = try Uint4(validating: UInt8((ump.word0 >> 24) & 0xF))
+        let channel = try Uint4(validating: UInt8((ump.word0 >> 16) & 0xF))
+        let addrValue = UInt16(bankByte) << 7 | UInt16(indexByte)
+        guard let addr = Midi2NRPNAddress(rawValue: addrValue) else {
+            throw MIDIError.malformedPacket("invalid address")
+        }
+        let delta = Swift.Int32(bitPattern: ump.word1)
+        self.init(group: group, channel: channel, address: addr, delta: delta)
+    }
 }

--- a/Sources/MIDI2/Midi2RPNRelative.swift
+++ b/Sources/MIDI2/Midi2RPNRelative.swift
@@ -1,3 +1,77 @@
 /// Registered Controller (relative).
-public struct Midi2RPNRelative {
+///
+/// Encodes a relative delta for a Registered Parameter Number (RPN)
+/// address. The message is transported as a 64-bit UMP Channel Voice packet
+/// with status nibble ``0x4``. The 14-bit address is split into a 7-bit bank
+/// and 7-bit index, each occupying one byte in the first word. The 32-bit
+/// delta is encoded as a two's complement value in the second word.
+public struct Midi2RPNRelative: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let address: Midi2RPNAddress
+    public let delta: Swift.Int32
+
+    public init(group: Uint4, channel: Uint4, address: Midi2RPNAddress, delta: Swift.Int32) {
+        self.group = group
+        self.channel = channel
+        self.address = address
+        self.delta = delta
+    }
+
+    /// Encodes the message into a Universal MIDI Packet.
+    public func ump() -> UmpPacket64 {
+        let raw = address.rawValue
+        let bank = UInt8((raw >> 7) & 0x7F)
+        let index = UInt8(raw & 0x7F)
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(0x4) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(bank) << 8 |
+                    UInt32(index)
+        return UmpPacket64(word0: word0, word1: UInt32(bitPattern: delta))
+    }
+
+    /// Failable initializer from a Universal MIDI Packet.
+    public init?(ump: UmpPacket64) {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else { return nil }
+        guard ((ump.word0 >> 20) & 0xF) == 0x4 else { return nil }
+        let bank = UInt8((ump.word0 >> 8) & 0xFF)
+        let index = UInt8(ump.word0 & 0xFF)
+        guard bank < 0x80, index < 0x80 else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        let addrValue = UInt16(bank) << 7 | UInt16(index)
+        guard let addr = Midi2RPNAddress(rawValue: addrValue) else { return nil }
+        let delta = Swift.Int32(bitPattern: ump.word1)
+        self.init(group: group, channel: channel, address: addr, delta: delta)
+    }
+
+    /// Parses a Universal MIDI Packet into a RPN relative message.
+    /// Throws ``MIDIError.malformedPacket`` if the packet is not a valid
+    /// RPN relative message.
+    public init(parsingUMP ump: UmpPacket64) throws {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else {
+            throw MIDIError.malformedPacket("expected mt 0x4 but got \(((ump.word0 >> 28) & 0xF))")
+        }
+        guard ((ump.word0 >> 20) & 0xF) == 0x4 else {
+            throw MIDIError.malformedPacket("expected status 0x4 but got \(((ump.word0 >> 20) & 0xF))")
+        }
+        let bankByte = UInt8((ump.word0 >> 8) & 0xFF)
+        let indexByte = UInt8(ump.word0 & 0xFF)
+        guard bankByte < 0x80 else {
+            throw MIDIError.malformedPacket("bank byte msb set")
+        }
+        guard indexByte < 0x80 else {
+            throw MIDIError.malformedPacket("index byte msb set")
+        }
+        let group = try Uint4(validating: UInt8((ump.word0 >> 24) & 0xF))
+        let channel = try Uint4(validating: UInt8((ump.word0 >> 16) & 0xF))
+        let addrValue = UInt16(bankByte) << 7 | UInt16(indexByte)
+        guard let addr = Midi2RPNAddress(rawValue: addrValue) else {
+            throw MIDIError.malformedPacket("invalid address")
+        }
+        let delta = Swift.Int32(bitPattern: ump.word1)
+        self.init(group: group, channel: channel, address: addr, delta: delta)
+    }
 }

--- a/Tests/MIDI2Tests/Midi2NRPNRelativeTests.swift
+++ b/Tests/MIDI2Tests/Midi2NRPNRelativeTests.swift
@@ -2,7 +2,27 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2NRPNRelativeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2NRPNRelative
+    func testEncodingDecoding() throws {
+        let group = Uint4(2)!
+        let channel = Uint4(3)!
+        let address = Midi2NRPNAddress(rawValue: 0x1234)!
+        let delta: Swift.Int32 = -123_456
+        let msg = Midi2NRPNRelative(group: group, channel: channel, address: address, delta: delta)
+        let pkt = msg.ump()
+        XCTAssertEqual(pkt.word0, 0x42532434)
+        XCTAssertEqual(pkt.word1, 0xFFFE1DC0)
+        let decoded = try Midi2NRPNRelative(parsingUMP: pkt)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testMalformed() {
+        let group = Uint4(2)!
+        let channel = Uint4(3)!
+        let address = Midi2NRPNAddress(rawValue: 0x1234)!
+        let msg = Midi2NRPNRelative(group: group, channel: channel, address: address, delta: 0)
+        let pkt = msg.ump()
+        // Corrupt message type
+        let bad = UmpPacket64(word0: pkt.word0 & 0x0FFFFFFF, word1: pkt.word1)
+        XCTAssertThrowsError(try Midi2NRPNRelative(parsingUMP: bad))
     }
 }

--- a/Tests/MIDI2Tests/Midi2RPNRelativeTests.swift
+++ b/Tests/MIDI2Tests/Midi2RPNRelativeTests.swift
@@ -2,7 +2,27 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2RPNRelativeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2RPNRelative
+    func testEncodingDecoding() throws {
+        let group = Uint4(1)!
+        let channel = Uint4(2)!
+        let address = Midi2RPNAddress(rawValue: 0x2345)!
+        let delta: Swift.Int32 = 123
+        let msg = Midi2RPNRelative(group: group, channel: channel, address: address, delta: delta)
+        let pkt = msg.ump()
+        XCTAssertEqual(pkt.word0, 0x41424645)
+        XCTAssertEqual(pkt.word1, 123)
+        let decoded = try Midi2RPNRelative(parsingUMP: pkt)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testMalformed() {
+        let group = Uint4(1)!
+        let channel = Uint4(2)!
+        let address = Midi2RPNAddress(rawValue: 0x2345)!
+        let msg = Midi2RPNRelative(group: group, channel: channel, address: address, delta: 0)
+        let pkt = msg.ump()
+        // Corrupt status nibble
+        let bad = UmpPacket64(word0: (pkt.word0 & ~0x00F00000) | UInt32(0x5 << 20), word1: pkt.word1)
+        XCTAssertThrowsError(try Midi2RPNRelative(parsingUMP: bad))
     }
 }


### PR DESCRIPTION
## Summary
- add support for encoding/decoding relative NRPN and RPN controller messages
- validate packets and expose throwing initializers for malformed data
- test NRPN/RPN relative roundtrip and error cases

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689d5c4c633883339ed740c64e94419d