### PR TITLE
Add absolute NRPN and RPN MIDI 2.0 messages with round-trip tests

### DIFF
--- a/Sources/MIDI2/Midi2NRPN.swift
+++ b/Sources/MIDI2/Midi2NRPN.swift
@@ -20,3 +20,80 @@ public enum Midi2NRPNAddress: Equatable {
         }
     }
 }
+
+/// Assignable Controller (absolute).
+///
+/// Carries a 32-bit value for a Non-Registered Parameter Number (NRPN)
+/// address. The message is encoded as a 64-bit Universal MIDI Packet with
+/// status nibble ``0x3``. The 14-bit address is split into a 7-bit bank and
+/// 7-bit index within the first word. The parameter value is stored in the
+/// second word.
+public struct Midi2NRPN: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let address: Midi2NRPNAddress
+    public let value: Swift.UInt32
+
+    public init(group: Uint4, channel: Uint4, address: Midi2NRPNAddress, value: Swift.UInt32) {
+        self.group = group
+        self.channel = channel
+        self.address = address
+        self.value = value
+    }
+
+    /// Encodes the message into a Universal MIDI Packet.
+    public func ump() -> UmpPacket64 {
+        let raw = address.rawValue
+        let bank = UInt8((raw >> 7) & 0x7F)
+        let index = UInt8(raw & 0x7F)
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(0x3) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(bank) << 8 |
+                    UInt32(index)
+        return UmpPacket64(word0: word0, word1: value)
+    }
+
+    /// Failable initializer from a Universal MIDI Packet.
+    public init?(ump: UmpPacket64) {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else { return nil }
+        guard ((ump.word0 >> 20) & 0xF) == 0x3 else { return nil }
+        let bank = UInt8((ump.word0 >> 8) & 0xFF)
+        let index = UInt8(ump.word0 & 0xFF)
+        guard bank < 0x80, index < 0x80 else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        let addrValue = Swift.UInt16(bank) << 7 | Swift.UInt16(index)
+        guard let addr = Midi2NRPNAddress(rawValue: addrValue) else { return nil }
+        let value = ump.word1
+        self.init(group: group, channel: channel, address: addr, value: value)
+    }
+
+    /// Parses a Universal MIDI Packet into an NRPN message.
+    /// Throws ``MIDIError.malformedPacket`` if the packet is not valid.
+    public init(parsingUMP ump: UmpPacket64) throws {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else {
+            throw MIDIError.malformedPacket("expected mt 0x4 but got \(((ump.word0 >> 28) & 0xF))")
+        }
+        guard ((ump.word0 >> 20) & 0xF) == 0x3 else {
+            throw MIDIError.malformedPacket("expected status 0x3 but got \(((ump.word0 >> 20) & 0xF))")
+        }
+        let bankByte = Swift.UInt8((ump.word0 >> 8) & 0xFF)
+        let indexByte = Swift.UInt8(ump.word0 & 0xFF)
+        guard bankByte < 0x80 else {
+            throw MIDIError.malformedPacket("bank byte msb set")
+        }
+        guard indexByte < 0x80 else {
+            throw MIDIError.malformedPacket("index byte msb set")
+        }
+        let group = try Uint4(validating: Swift.UInt8((ump.word0 >> 24) & 0xF))
+        let channel = try Uint4(validating: Swift.UInt8((ump.word0 >> 16) & 0xF))
+        let addrValue = Swift.UInt16(bankByte) << 7 | Swift.UInt16(indexByte)
+        guard let addr = Midi2NRPNAddress(rawValue: addrValue) else {
+            throw MIDIError.malformedPacket("invalid address")
+        }
+        let value = ump.word1
+        self.init(group: group, channel: channel, address: addr, value: value)
+    }
+}

--- a/Sources/MIDI2/Midi2RPN.swift
+++ b/Sources/MIDI2/Midi2RPN.swift
@@ -35,3 +35,80 @@ public enum Midi2RPNAddress: Equatable {
         }
     }
 }
+
+/// Registered Controller (absolute).
+///
+/// Carries a 32-bit value for a Registered Parameter Number (RPN)
+/// address. The message is encoded as a 64-bit Universal MIDI Packet with
+/// status nibble ``0x2``. The 14-bit address is split into a 7-bit bank and
+/// 7-bit index occupying the third and fourth bytes of the first word. The
+/// parameter value is stored in the second word.
+public struct Midi2RPN: Equatable {
+    public let group: Uint4
+    public let channel: Uint4
+    public let address: Midi2RPNAddress
+    public let value: Swift.UInt32
+
+    public init(group: Uint4, channel: Uint4, address: Midi2RPNAddress, value: Swift.UInt32) {
+        self.group = group
+        self.channel = channel
+        self.address = address
+        self.value = value
+    }
+
+    /// Encodes the message into a Universal MIDI Packet.
+    public func ump() -> UmpPacket64 {
+        let raw = address.rawValue
+        let bank = UInt8((raw >> 7) & 0x7F)
+        let index = UInt8(raw & 0x7F)
+        let word0 = UInt32(0x4 << 28) |
+                    UInt32(group.rawValue) << 24 |
+                    UInt32(0x2) << 20 |
+                    UInt32(channel.rawValue) << 16 |
+                    UInt32(bank) << 8 |
+                    UInt32(index)
+        return UmpPacket64(word0: word0, word1: value)
+    }
+
+    /// Failable initializer from a Universal MIDI Packet.
+    public init?(ump: UmpPacket64) {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else { return nil }
+        guard ((ump.word0 >> 20) & 0xF) == 0x2 else { return nil }
+        let bank = UInt8((ump.word0 >> 8) & 0xFF)
+        let index = UInt8(ump.word0 & 0xFF)
+        guard bank < 0x80, index < 0x80 else { return nil }
+        guard let group = Uint4(UInt8((ump.word0 >> 24) & 0xF)) else { return nil }
+        guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
+        let addrValue = Swift.UInt16(bank) << 7 | Swift.UInt16(index)
+        guard let addr = Midi2RPNAddress(rawValue: addrValue) else { return nil }
+        let value = ump.word1
+        self.init(group: group, channel: channel, address: addr, value: value)
+    }
+
+    /// Parses a Universal MIDI Packet into an RPN message.
+    /// Throws ``MIDIError.malformedPacket`` if the packet is not valid.
+    public init(parsingUMP ump: UmpPacket64) throws {
+        guard (ump.word0 >> 28) & 0xF == 0x4 else {
+            throw MIDIError.malformedPacket("expected mt 0x4 but got \(((ump.word0 >> 28) & 0xF))")
+        }
+        guard ((ump.word0 >> 20) & 0xF) == 0x2 else {
+            throw MIDIError.malformedPacket("expected status 0x2 but got \(((ump.word0 >> 20) & 0xF))")
+        }
+        let bankByte = Swift.UInt8((ump.word0 >> 8) & 0xFF)
+        let indexByte = Swift.UInt8(ump.word0 & 0xFF)
+        guard bankByte < 0x80 else {
+            throw MIDIError.malformedPacket("bank byte msb set")
+        }
+        guard indexByte < 0x80 else {
+            throw MIDIError.malformedPacket("index byte msb set")
+        }
+        let group = try Uint4(validating: Swift.UInt8((ump.word0 >> 24) & 0xF))
+        let channel = try Uint4(validating: Swift.UInt8((ump.word0 >> 16) & 0xF))
+        let addrValue = Swift.UInt16(bankByte) << 7 | Swift.UInt16(indexByte)
+        guard let addr = Midi2RPNAddress(rawValue: addrValue) else {
+            throw MIDIError.malformedPacket("invalid address")
+        }
+        let value = ump.word1
+        self.init(group: group, channel: channel, address: addr, value: value)
+    }
+}

--- a/Tests/MIDI2Tests/Midi2NRPNTests.swift
+++ b/Tests/MIDI2Tests/Midi2NRPNTests.swift
@@ -2,7 +2,41 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2NRPNTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2NRPN
+    func testRoundTrip() throws {
+        let group = Uint4(0x2)!
+        let channel = Uint4(0x7)!
+        let address = Midi2NRPNAddress(rawValue: 0x1234)!
+        let value: UInt32 = 0xDEADBEEF
+        let msg = Midi2NRPN(group: group, channel: channel, address: address, value: value)
+        let pkt = msg.ump()
+        let decoded = try Midi2NRPN(parsingUMP: pkt)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testEdgeCases() throws {
+        let group = Uint4(0x0)!
+        let channel = Uint4(0xF)!
+        let minAddr = Midi2NRPNAddress(rawValue: 0x0000)!
+        let min = Midi2NRPN(group: group, channel: channel, address: minAddr, value: 0)
+        let decodedMin = try Midi2NRPN(parsingUMP: min.ump())
+        XCTAssertEqual(decodedMin, min)
+
+        let maxAddr = Midi2NRPNAddress(rawValue: 0x3FFF)!
+        let max = Midi2NRPN(group: group, channel: channel, address: maxAddr, value: 0xFFFF_FFFF)
+        let decodedMax = try Midi2NRPN(parsingUMP: max.ump())
+        XCTAssertEqual(decodedMax, max)
+    }
+
+    func testDecodeFailure() {
+        let group = Uint4(0x1)!
+        let channel = Uint4(0x2)!
+        let address = Midi2NRPNAddress(rawValue: 0x1234)!
+        let value: UInt32 = 0x01020304
+        let msg = Midi2NRPN(group: group, channel: channel, address: address, value: value)
+        let pkt = msg.ump()
+        let bad = UmpPacket64(word0: (pkt.word0 & ~0x00F00000) | UInt32(0x2 << 20), word1: pkt.word1)
+        XCTAssertThrowsError(try Midi2NRPN(parsingUMP: bad))
+        let badIndex = UmpPacket64(word0: pkt.word0 | 0x00000080, word1: pkt.word1)
+        XCTAssertThrowsError(try Midi2NRPN(parsingUMP: badIndex))
     }
 }

--- a/Tests/MIDI2Tests/Midi2RPNTests.swift
+++ b/Tests/MIDI2Tests/Midi2RPNTests.swift
@@ -2,7 +2,41 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2RPNTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2RPN
+    func testRoundTrip() throws {
+        let group = Uint4(0x3)!
+        let channel = Uint4(0x4)!
+        let address = Midi2RPNAddress(rawValue: 0x2345)!
+        let value: UInt32 = 0xCAFEBABE
+        let msg = Midi2RPN(group: group, channel: channel, address: address, value: value)
+        let pkt = msg.ump()
+        let decoded = try Midi2RPN(parsingUMP: pkt)
+        XCTAssertEqual(decoded, msg)
+    }
+
+    func testEdgeCases() throws {
+        let group = Uint4(0x0)!
+        let channel = Uint4(0x0)!
+        let minAddr = Midi2RPNAddress(rawValue: 0x0000)!
+        let min = Midi2RPN(group: group, channel: channel, address: minAddr, value: 0)
+        let decodedMin = try Midi2RPN(parsingUMP: min.ump())
+        XCTAssertEqual(decodedMin, min)
+
+        let maxAddr = Midi2RPNAddress(rawValue: 0x3FFF)!
+        let max = Midi2RPN(group: group, channel: channel, address: maxAddr, value: 0xFFFF_FFFF)
+        let decodedMax = try Midi2RPN(parsingUMP: max.ump())
+        XCTAssertEqual(decodedMax, max)
+    }
+
+    func testDecodeFailure() {
+        let group = Uint4(0x1)!
+        let channel = Uint4(0x2)!
+        let address = Midi2RPNAddress(rawValue: 0x2345)!
+        let value: UInt32 = 0x0A0B0C0D
+        let msg = Midi2RPN(group: group, channel: channel, address: address, value: value)
+        let pkt = msg.ump()
+        let bad = UmpPacket64(word0: (pkt.word0 & ~0x00F00000) | UInt32(0x3 << 20), word1: pkt.word1)
+        XCTAssertThrowsError(try Midi2RPN(parsingUMP: bad))
+        let badBank = UmpPacket64(word0: pkt.word0 | 0x00008000, word1: pkt.word1)
+        XCTAssertThrowsError(try Midi2RPN(parsingUMP: badBank))
     }
 }


### PR DESCRIPTION
## Summary
- Add Midi2NRPN and Midi2RPN structs for absolute NRPN/RPN messages with 32-bit values
- Implement encoding, decoding, and validation logic
- Cover round-trip, boundary, and failure cases in new tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689d5ebfa2e48333b895349c312459be