### PR TITLE
Add range-checked NoteAttributeType initializers and tests

### DIFF
--- a/Sources/MIDI2/ChannelVoice/NoteOff.swift
+++ b/Sources/MIDI2/ChannelVoice/NoteOff.swift
@@ -41,7 +41,7 @@ public struct NoteOff: Equatable {
         let byte2 = UInt8((ump.word0 >> 8) & 0xFF)
         guard let noteNumber = Uint7(byte2) else { return nil }
         let byte3 = UInt8(ump.word0 & 0xFF)
-        let attributeType = NoteAttributeType(byte3)
+        guard let attributeType = NoteAttributeType(byte3) else { return nil }
         let byte4 = UInt8((ump.word1 >> 24) & 0xFF)
         let byte5 = UInt8((ump.word1 >> 16) & 0xFF)
         let byte6 = UInt8((ump.word1 >> 8) & 0xFF)

--- a/Sources/MIDI2/Midi2NoteOn.swift
+++ b/Sources/MIDI2/Midi2NoteOn.swift
@@ -45,7 +45,7 @@ public struct Midi2NoteOn: Equatable {
         guard ((ump.word0 >> 20) & 0xF) == 0x9 else { return nil }
         guard let channel = Uint4(UInt8((ump.word0 >> 16) & 0xF)) else { return nil }
         guard let note = Uint7(UInt8((ump.word0 >> 8) & 0xFF)) else { return nil }
-        let attrType = NoteAttributeType(UInt8(ump.word0 & 0xFF))
+        guard let attrType = NoteAttributeType(UInt8(ump.word0 & 0xFF)) else { return nil }
         let velocity = UInt16((ump.word1 >> 16) & 0xFFFF)
         let attrData = UInt16(ump.word1 & 0xFFFF)
         self.init(group: group, channel: channel, note: note, velocity: velocity, attributeType: attrType, attributeData: attrData)
@@ -63,7 +63,7 @@ public struct Midi2NoteOn: Equatable {
         let group = try Uint4(validating: UInt8((ump.word0 >> 24) & 0xF))
         let channel = try Uint4(validating: UInt8((ump.word0 >> 16) & 0xF))
         let note = try Uint7(validating: UInt8((ump.word0 >> 8) & 0xFF))
-        let attrType = NoteAttributeType(UInt8(ump.word0 & 0xFF))
+        let attrType = try NoteAttributeType(validating: UInt8(ump.word0 & 0xFF))
         let velocity = UInt16((ump.word1 >> 16) & 0xFFFF)
         let attrData = UInt16(ump.word1 & 0xFFFF)
         self.init(group: group, channel: channel, note: note, velocity: velocity, attributeType: attrType, attributeData: attrData)

--- a/Sources/MIDI2/NoteAttributeType.swift
+++ b/Sources/MIDI2/NoteAttributeType.swift
@@ -2,9 +2,20 @@
 public struct NoteAttributeType: Equatable, Hashable, Sendable {
     public let rawValue: UInt8
 
-    public init(_ rawValue: UInt8) {
+    /// Creates a new `NoteAttributeType` if `rawValue` is in the range `0...0x7F`.
+    /// Returns `nil` for out-of-range values.
+    public init?(_ rawValue: UInt8) {
+        guard rawValue < 0x80 else { return nil }
         self.rawValue = rawValue
     }
 
-    public static let none = NoteAttributeType(0)
+    /// Creates a new `NoteAttributeType`, throwing an error if `rawValue` is out of range.
+    public init(validating rawValue: UInt8) throws {
+        guard rawValue < 0x80 else {
+            throw MIDIError.valueOutOfRange(name: "NoteAttributeType", value: UInt64(rawValue), range: 0...0x7F)
+        }
+        self.rawValue = rawValue
+    }
+
+    public static let none = NoteAttributeType(0)!
 }

--- a/Tests/MIDI2Tests/ChannelVoice/NoteOffTests.swift
+++ b/Tests/MIDI2Tests/ChannelVoice/NoteOffTests.swift
@@ -8,7 +8,7 @@ final class NoteOffTests: XCTestCase {
             channel: Uint4(0x2)!,
             noteNumber: Uint7(0x3C)!,
             velocity: 0x1234,
-            attributeType: NoteAttributeType(0x56),
+            attributeType: NoteAttributeType(0x56)!,
             attributeData: 0x789A
         )
         let packet = message.ump()

--- a/Tests/MIDI2Tests/NoteAttributeTypeTests.swift
+++ b/Tests/MIDI2Tests/NoteAttributeTypeTests.swift
@@ -2,7 +2,34 @@ import XCTest
 @testable import MIDI2
 
 final class NoteAttributeTypeTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test NoteAttributeType
+    func testRoundTrip() throws {
+        let raw: UInt8 = 0x7F
+        let attr = try XCTUnwrap(NoteAttributeType(raw))
+        XCTAssertEqual(attr.rawValue, raw)
+    }
+
+    func testGoldenVectors() {
+        XCTAssertEqual(NoteAttributeType(0x00)?.rawValue, 0x00)
+        XCTAssertEqual(NoteAttributeType(0x7F)?.rawValue, 0x7F)
+    }
+
+    func testError() {
+        XCTAssertNil(NoteAttributeType(0x80))
+        XCTAssertThrowsError(try NoteAttributeType(validating: 0x80))
+    }
+
+    func testFuzz() throws {
+        for _ in 0..<1_000 {
+            let raw = UInt8.random(in: 0x0...0x7F)
+            let attr = try NoteAttributeType(validating: raw)
+            XCTAssertEqual(attr.rawValue, raw)
+        }
+
+        for _ in 0..<1_000 {
+            let raw = UInt8.random(in: 0x80...UInt8.max)
+            XCTAssertNil(NoteAttributeType(raw))
+            XCTAssertThrowsError(try NoteAttributeType(validating: raw))
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- add failable and throwing initializers for NoteAttributeType ensuring 0…0x7F
- validate NoteOn/NoteOff parsing using new initializer
- add comprehensive NoteAttributeType tests for valid/invalid ranges

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689d60826bb483339d26188dd6f400dc