### PR TITLE
Add MIDI 2.0 playground examples and README links

### DIFF
--- a/Examples/FlexTiming.playground/Contents.swift
+++ b/Examples/FlexTiming.playground/Contents.swift
@@ -1,0 +1,7 @@
+import MIDI2
+
+// Create a Flex tempo message and decode it.
+let tempo = FlexDataTempo(beatsPerMinute: 120.0)
+let packet = tempo.encode(group: 0)
+let decoded = FlexDataTempo.decode(packet)
+print(decoded?.beatsPerMinute ?? 0)

--- a/Examples/MDS.playground/Contents.swift
+++ b/Examples/MDS.playground/Contents.swift
@@ -1,0 +1,16 @@
+import MIDI2
+
+// Build a Mixed Data Set chunk and round-trip through UMP packets.
+let chunk = MixedDataSet.Chunk(
+    mdsID: Uint4(1)!,
+    numberOfChunks: 1,
+    chunkNumber: 1,
+    manufacturerID: 0x7D00,
+    deviceID: 0x0001,
+    subID1: 0x0002,
+    subID2: 0x0003,
+    data: [0x01, 0x02, 0x03]
+)
+let packets = try MixedDataSet.fragment(chunk: chunk)
+let rebuilt = try MixedDataSet.reassemble(packets)
+print(rebuilt)

--- a/Examples/MIDICIHandshake.playground/Contents.swift
+++ b/Examples/MIDICIHandshake.playground/Contents.swift
@@ -1,0 +1,24 @@
+import MIDI2
+
+// Construct a MIDI-CI profile inquiry and parse the reply.
+let requestBody = MidiCiProfilesBody(
+    command: .inquiry,
+    profileId: "com.example.profile",
+    target: .channel,
+    channels: [Uint4(0)!]
+)
+let requestEnv = MidiCiEnvelope(scope: .nonRealtime, subId2: 0x72, version: 1, body: .profiles(requestBody))
+let requestPayload = requestEnv.sysEx7Payload()
+
+let parsed = try MidiCiEnvelope(sysEx7Payload: requestPayload)
+if case let .profiles(body) = parsed.body {
+    let replyBody = MidiCiProfilesBody(
+        command: .reply,
+        profileId: body.profileId,
+        target: body.target,
+        channels: body.channels
+    )
+    let replyEnv = MidiCiEnvelope(scope: .nonRealtime, subId2: 0x72, version: 1, body: .profiles(replyBody))
+    let replyPayload = replyEnv.sysEx7Payload()
+    print(replyPayload.count)
+}

--- a/Examples/SysEx8.playground/Contents.swift
+++ b/Examples/SysEx8.playground/Contents.swift
@@ -1,0 +1,7 @@
+import MIDI2
+
+// Fragment a SysEx8 payload into UMP packets and reassemble it.
+let payload: [UInt8] = [0x10, 0x20, 0x30]
+let packets = try SysEx8.fragment(manufacturerID: [0x00, 0x20, 0x33], payload: payload)
+let (mfr, rebuilt) = try SysEx8.reassemble(packets)
+print(mfr, rebuilt)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ import MIDI2
 
 ## Examples
 
-See the `Examples/` directory for Swift Playgrounds demonstrating common tasks.
+See the `Examples/` directory for Swift Playgrounds demonstrating common tasks:
+
+- [Basic usage](Examples/BasicUsage.playground)
+- [Streaming SysEx7 data](Examples/SysEx7.playground)
+- [Streaming SysEx8 data](Examples/SysEx8.playground)
+- [Mixed Data Set chunk transfer](Examples/MDS.playground)
+- [Flex tempo message](Examples/FlexTiming.playground)
+- [MIDI-CI handshake](Examples/MIDICIHandshake.playground)
 
 ### Encoding a Channel Voice Message
 


### PR DESCRIPTION
## Summary
- Provide SysEx8, Mixed Data Set, Flex tempo, and MIDI-CI handshake playgrounds
- Link new example playgrounds from README

## Testing
- `swift build`
- `swift test`
- `swiftc -I .build/x86_64-unknown-linux-gnu/debug/Modules -L .build/x86_64-unknown-linux-gnu/debug -lMIDI2 Examples/SysEx8.playground/Contents.swift -typecheck`
- `swiftc -I .build/x86_64-unknown-linux-gnu/debug/Modules -L .build/x86_64-unknown-linux-gnu/debug -lMIDI2 Examples/MDS.playground/Contents.swift -typecheck`
- `swiftc -I .build/x86_64-unknown-linux-gnu/debug/Modules -L .build/x86_64-unknown-linux-gnu/debug -lMIDI2 Examples/FlexTiming.playground/Contents.swift -typecheck`
- `swiftc -I .build/x86_64-unknown-linux-gnu/debug/Modules -L .build/x86_64-unknown-linux-gnu/debug -lMIDI2 Examples/MIDICIHandshake.playground/Contents.swift -typecheck`

------
https://chatgpt.com/codex/tasks/task_b_689d6188c2a483338fd9dd487295afce