### PR TITLE
Add tests for status nibbles and MIDI1 channel voice

### DIFF
--- a/Sources/MIDI2/Midi2StatusNibble.swift
+++ b/Sources/MIDI2/Midi2StatusNibble.swift
@@ -1,3 +1,16 @@
-/// High 4 bits of a MIDI 2.0 status byte.
-public struct Midi2StatusNibble {
+/// High 4 bits of a MIDI 2.0 status byte (0x8-0xF).
+public struct Midi2StatusNibble: Equatable, Hashable {
+    public let rawValue: UInt8
+
+    public init?(_ rawValue: UInt8) {
+        guard (0x8...0xF).contains(rawValue) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: UInt8) throws {
+        guard (0x8...0xF).contains(rawValue) else {
+            throw MIDIError.valueOutOfRange(name: "Midi2StatusNibble", value: UInt64(rawValue), range: 0x8...0xF)
+        }
+        self.rawValue = rawValue
+    }
 }

--- a/Tests/MIDI2Tests/Midi1ChannelVoiceBodyTests.swift
+++ b/Tests/MIDI2Tests/Midi1ChannelVoiceBodyTests.swift
@@ -2,7 +2,31 @@ import XCTest
 @testable import MIDI2
 
 final class Midi1ChannelVoiceBodyTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi1ChannelVoiceBody
+    func testRoundTrip() throws {
+        let g = Uint4(0)!
+        let msg = Midi1ChannelVoiceMessage.noteOn(group: g, channel: Uint4(0)!, note: Uint7(0x3C)!, velocity: Uint7(0x40)!)
+        let packet = msg.ump()
+        XCTAssertEqual(packet.word, 0x20903C40)
+        XCTAssertEqual(Midi1ChannelVoiceMessage(ump: packet), msg)
+        XCTAssertEqual(try Midi1ChannelVoiceMessage(parsingUMP: packet), msg)
+
+        let bytes = [UInt8](msg.midi1Bytes())
+        XCTAssertEqual(bytes, [0x90, 0x3C, 0x40])
+        XCTAssertEqual(Midi1ChannelVoiceMessage(midi1Bytes: bytes, group: g)?.midi1Bytes(), bytes)
+        XCTAssertEqual(try Midi1ChannelVoiceMessage(parsingMidi1Bytes: bytes, group: g).midi1Bytes(), bytes)
+    }
+
+    func testInvalidMessageType() {
+        let g = Uint4(0)!
+        let packet = UmpPacket32(mt: 0x0, group: g, status: 0, data1: 0, data2: 0)
+        XCTAssertNil(Midi1ChannelVoiceMessage(ump: packet))
+        XCTAssertThrowsError(try Midi1ChannelVoiceMessage(parsingUMP: packet))
+    }
+
+    func testRangeEnforcement() {
+        let g = Uint4(0)!
+        let bytes: [UInt8] = [0x90, 0xFF, 0x40]
+        XCTAssertNil(Midi1ChannelVoiceMessage(midi1Bytes: bytes, group: g))
+        XCTAssertThrowsError(try Midi1ChannelVoiceMessage(parsingMidi1Bytes: bytes, group: g))
     }
 }

--- a/Tests/MIDI2Tests/Midi1StatusNibbleTests.swift
+++ b/Tests/MIDI2Tests/Midi1StatusNibbleTests.swift
@@ -2,7 +2,21 @@ import XCTest
 @testable import MIDI2
 
 final class Midi1StatusNibbleTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi1StatusNibble
+    func testRoundTrip() {
+        for raw in 0x8...0xE {
+            let status = Midi1StatusNibble(UInt8(raw))
+            XCTAssertNotNil(status)
+            XCTAssertEqual(status?.rawValue, UInt8(raw))
+        }
+    }
+
+    func testGoldenVectors() {
+        XCTAssertEqual(Midi1StatusNibble(0x8), .noteOff)
+        XCTAssertEqual(Midi1StatusNibble(0xE), .pitchBend)
+    }
+
+    func testInvalidValues() {
+        XCTAssertNil(Midi1StatusNibble(0x7))
+        XCTAssertNil(Midi1StatusNibble(0xF))
     }
 }

--- a/Tests/MIDI2Tests/Midi2StatusNibbleTests.swift
+++ b/Tests/MIDI2Tests/Midi2StatusNibbleTests.swift
@@ -2,7 +2,20 @@ import XCTest
 @testable import MIDI2
 
 final class Midi2StatusNibbleTests: XCTestCase {
-    func testPlaceholder() {
-        // TODO: Test Midi2StatusNibble
+    func testRoundTrip() throws {
+        for raw in 0x8...0xF {
+            let nibble = try Midi2StatusNibble(validating: UInt8(raw))
+            XCTAssertEqual(nibble.rawValue, UInt8(raw))
+        }
+    }
+
+    func testGoldenVectors() {
+        XCTAssertEqual(Midi2StatusNibble(0x8)?.rawValue, 0x8)
+        XCTAssertEqual(Midi2StatusNibble(0xF)?.rawValue, 0xF)
+    }
+
+    func testInvalidValues() {
+        XCTAssertNil(Midi2StatusNibble(0x7))
+        XCTAssertThrowsError(try Midi2StatusNibble(validating: 0x7))
     }
 }


### PR DESCRIPTION
## Summary
- implement range-checked `Midi2StatusNibble`
- add round-trip and error tests for Midi1 and Midi2 status nibbles
- add golden-vector tests for MIDI1 channel voice messages

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689d6353325883338104aa84127faf6f