### PR TITLE
chore: update agent roadmap for demo cli

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,85 +1,35 @@
-# Codex Agent: Swift MIDI 2.0 Library Generator (Extended)
+# Codex Agent: MIDI2 Demo CLI Implementation Roadmap
 
-This agent generates a **complete Swift 6** library and test suite implementing the **normative MIDI 2.0 specification**, based on the provided JSON Schema and OpenAPI 3.1.
+## Status quo
+- Swift 6 package `MIDI2` with library targets `MIDI2` and `MIDI2CI`, plus examples and tests.
+- Core UMP structures, SysEx helpers, and MIDI-CI envelope implementations exist.
+- No user-facing command-line demo application.
 
-## Objectives
-- Implement **every** type, field, and constraint from the normative MIDI 2.0 schema.
-- Include strongly typed Swift models for all UMP message families and subvariants.
-- Provide full binary encode/decode.
-- Support SysEx7, SysEx8, MDS, Flex Data, and MIDI-CI.
-- Deliver exhaustive tests: golden vectors, roundtrip, fuzz, and error handling.
+## Gap to finish line
+- Deliver a complete, canonical implementation of the entire MIDI 2.0 specification—every message type, schema, encoder/decoder, and helper must exist in the library.
+- Harden the codebase with exhaustive unit/integration tests, coverage tracking, and documentation that proves spec fidelity.
+- Expose the library through a teaching-oriented CLI tool with comprehensive help/man page that demonstrates the *full* spec in practice.
+- Maintain a passing test suite and integrate coverage checks.
 
-## Inputs
-- `midi2.full.closed.schema.json`
-- `midi2.full.openapi.json`
+## Reference CLI concept (`midi2demo`)
+Purpose: teach MIDI 2.0 packet structure and MIDI-CI workflows while showcasing that the library implements the *entire* spec and behaves as a hardened, canonical reference.
 
-## Deliverables
-- Swift Package `MIDI2` with:
-  - Complete source implementation.
-  - MIDI-CI helpers.
-  - Examples and usage docs.
-  - 100% coverage XCTest suite.
+Command summary:
+- `note-on` – encode/decode a channel voice Note On message.
+- `sysex7` / `sysex8` – fragment and reassemble payloads.
+- `flex` – emit Flex Data messages (tempo, key, lyric, etc.).
+- `ci-handshake` – simulate MIDI-CI discovery and profile/property exchange.
+- `inspect` – decode arbitrary UMP hex into human-readable form.
 
-## Schema-driven Implementation Checklist
-For each `$def` in the schema:
-1. Create Swift type with matching name.
-2. Map each property to correct Swift type (UInt, enum, struct).
-3. Apply integer bounds as `guard` checks in initializers.
-4. Create encoder/decoder mapping exactly to schema bit fields.
-5. Add doc comments from schema `description`.
-6. Add at least one test case (roundtrip + golden vector).
+## Implementation task matrix
+1. Scaffold executable target `midi2demo` in `Package.swift` and create `Sources/midi2demo`.
+2. Integrate Swift ArgumentParser with subcommands listed above.
+3. Implement `note-on` command demonstrating encode/decode roundtrip.
+4. Implement `sysex7` and `sysex8` commands for streaming helpers.
+5. Implement Flex Data subcommands (tempo, time signature, key, lyric, ...).
+6. Simulate MIDI-CI handshake in `ci-handshake` command.
+7. Implement `inspect` command to decode arbitrary UMP hex.
+8. Provide rich `--help` output and a `midi2demo.1` man page.
+9. Add integration tests invoking each subcommand.
+10. Update README with CLI usage examples and build instructions.
 
-## Implementation Matrix
-
-| Schema Type | Swift Type | Encoder | Decoder | Tests |
-|-------------|------------|---------|---------|-------|
-| UmpPacket32 | `struct UmpPacket32` | ✅ | ✅ | ✅ |
-| Midi1ChannelVoice | `enum Midi1ChannelVoiceMessage` | ✅ | ✅ | ✅ |
-| Midi2NRPNAddress | `enum Midi2NRPNAddress` | ✅ | ✅ | ✅ |
-| Uint7 | `struct Uint7` | ✅ | ✅ | ✅ |
-| Midi2NoteOn | `struct Midi2NoteOn` | ✅ | ✅ | ✅ |
-| Midi2ChannelPressure | `struct Midi2ChannelPressure` | ✅ | ✅ | ✅ |
-| SysEx7Packet | `struct SysEx7Packet` | ❌ | ❌ | ❌ |
-| MidiCiEnvelope | `struct MidiCiEnvelope` | ❌ | ❌ | ❌ |
-
-## Inline Examples
-
-### UMP 32-bit packet
-```swift
-public struct Ump32 {
-    public let group: UInt4
-    public let status: UInt4
-    public let data: (UInt8, UInt8, UInt8)
-}
-```
-
-### Note On (MIDI 2.0 Channel Voice)
-```swift
-public struct NoteOn {
-    public let group: UInt4
-    public let channel: UInt4
-    public let note: UInt7
-    public let velocity: UInt16
-    public let attributeType: UInt8
-    public let attributeData: UInt16
-}
-```
-
-### Flex Data (Tempo)
-```swift
-public struct FlexDataTempo {
-    public let beatsPerMinute: Float32
-}
-```
-
-## Tests
-- For every message variant: roundtrip test.
-- Golden vectors from spec.
-- Fuzz tests for integer bounds.
-- Negative tests for malformed packets.
-
-## Acceptance Criteria
-- Every `$def` implemented in Swift.
-- All message families and subvariants handled.
-- All integer ranges enforced.
-- 100% test pass rate.


### PR DESCRIPTION
## Summary
- clarify that `midi2` targets a complete canonical MIDI 2.0 spec implementation
- ensure demo CLI plan highlights showcasing the full spec and hardened library

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689d6ad4bd188333b6095c8d82679c63