### PR TITLE
Add midi2demo CLI with Note On example

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,14 +6,21 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16)],
     products: [
         .library(name: "MIDI2", targets: ["MIDI2"]),
-        .library(name: "MIDI2CI", targets: ["MIDI2CI"])
+        .library(name: "MIDI2CI", targets: ["MIDI2CI"]),
+        .executable(name: "midi2demo", targets: ["midi2demo"])
     ],
     dependencies: [
-        .package(url: "https://github.com/typelift/SwiftCheck.git", from: "0.12.0")
+        .package(url: "https://github.com/typelift/SwiftCheck.git", from: "0.12.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0")
     ],
     targets: [
         .target(name: "MIDI2"),
         .target(name: "MIDI2CI", dependencies: ["MIDI2"]),
+        .executableTarget(name: "midi2demo", dependencies: [
+            "MIDI2",
+            "MIDI2CI",
+            .product(name: "ArgumentParser", package: "swift-argument-parser")
+        ]),
         .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2", "MIDI2CI"]),
         .testTarget(name: "Fuzz", dependencies: ["MIDI2", "SwiftCheck"], path: "Tests/Fuzz")
     ]

--- a/README.md
+++ b/README.md
@@ -3,21 +3,22 @@
 Work‑in‑progress Swift 6 library for building and parsing **MIDI 2.0 Universal MIDI
 Packets (UMP)**. The package is generated from the normative JSON Schema and
 OpenAPI definitions and currently provides core UMP structures, SysEx7/SysEx8
-streaming utilities, and MIDI‑CI envelope helpers. Coverage of the full
-specification and a teaching‑oriented CLI are still in progress.
+streaming utilities, MIDI‑CI envelope helpers, and an evolving
+`midi2demo` CLI for experimenting with the specification.
 
 ## Features
 
 - Core UMP message structures with binary encoder/decoder.
 - SysEx7 and SysEx8 streaming helpers.
 - MIDI‑CI envelope support.
+- Teaching‑oriented `midi2demo` CLI.
 - Examples and XCTest test suite.
 
 ## Roadmap
 
 - Expand implementation to cover the entire MIDI 2.0 specification.
-- Provide a `midi2demo` CLI showcasing encoding, streaming, Flex Data,
-  MIDI‑CI handshake, and packet inspection.
+- Expand the `midi2demo` CLI with streaming, Flex Data, MIDI‑CI handshake,
+  and packet inspection commands.
 - Harden the codebase with additional documentation and integration tests.
 
 ## Installation
@@ -35,6 +36,17 @@ Then import the library:
 ```swift
 import MIDI2
 ```
+
+## midi2demo CLI
+
+Build and run the teaching-oriented CLI to experiment with MIDI 2.0 messages:
+
+```
+swift run midi2demo note-on 60 100
+```
+
+The command prints the encoded Universal MIDI Packet and decodes it back to
+human-readable fields.
 
 ## Examples
 

--- a/Sources/midi2demo/main.swift
+++ b/Sources/midi2demo/main.swift
@@ -1,0 +1,51 @@
+import ArgumentParser
+import MIDI2
+import MIDI2CI
+
+struct NoteOn: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "note-on",
+        abstract: "Encode and decode a MIDI 2.0 Note On message."
+    )
+
+    @Option(name: [.short, .long], help: "Group number (0-15).")
+    var group: UInt8 = 0
+
+    @Option(name: [.short, .long], help: "Channel number (0-15).")
+    var channel: UInt8 = 0
+
+    @Argument(help: "Note number (0-127).")
+    var note: UInt8
+
+    @Argument(help: "Velocity value (0-65535).")
+    var velocity: UInt16
+
+    func run() throws {
+        guard let groupVal = Uint4(group),
+              let channelVal = Uint4(channel),
+              let noteVal = Uint7(note) else {
+            throw ValidationError("Group, channel, or note out of range")
+        }
+
+        let message = Midi2NoteOn(
+            group: groupVal,
+            channel: channelVal,
+            note: noteVal,
+            velocity: velocity
+        )
+        let packet = message.ump()
+        print(String(format: "UMP: 0x%08X 0x%08X", packet.word0, packet.word1))
+        if let decoded = Midi2NoteOn(ump: packet) {
+            print("Decoded -> group: \(decoded.group.rawValue) channel: \(decoded.channel.rawValue) note: \(decoded.note.rawValue) velocity: \(decoded.velocity)")
+        }
+    }
+}
+
+struct Midi2Demo: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Teaching-oriented MIDI 2.0 demo CLI",
+        subcommands: [NoteOn.self]
+    )
+}
+
+Midi2Demo.main()


### PR DESCRIPTION
## Summary
- add `midi2demo` executable target using Swift ArgumentParser
- implement `note-on` subcommand demonstrating MIDI 2.0 encoding/decoding
- document CLI usage in README

## Testing
- `swift test`
- `swift run midi2demo note-on 60 100`


------
https://chatgpt.com/codex/tasks/task_b_689d6fca03c083339834f3ff32341ad7