### PR TITLE
Add Flex Data CLI subcommands

### DIFF
--- a/Sources/midi2demo/Flex.swift
+++ b/Sources/midi2demo/Flex.swift
@@ -1,0 +1,216 @@
+import ArgumentParser
+import MIDI2
+import Foundation
+
+struct Flex: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "flex",
+        abstract: "Emit Flex Data messages",
+        subcommands: [
+            Tempo.self,
+            TimeSignature.self,
+            Key.self,
+            Lyric.self,
+            Metronome.self,
+            ChordName.self,
+            Text.self,
+            Ruby.self
+        ]
+    )
+}
+
+extension Flex {
+    struct Tempo: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Send a Flex Tempo message"
+        )
+
+        @Option(name: .long, help: "Group number (0-15).")
+        var group: UInt8 = 0
+
+        @Argument(help: "Tempo in beats per minute")
+        var bpm: Double
+
+        func run() throws {
+            let tempo = FlexDataTempo(beatsPerMinute: bpm)
+            let packet = tempo.encode(group: group)
+            print(String(format: "UMP: 0x%08X 0x%08X 0x%08X 0x%08X",
+                         packet.word0, packet.word1, packet.word2, packet.word3))
+            if let decoded = FlexDataTempo.decode(packet) {
+                print("Decoded -> BPM: \(decoded.beatsPerMinute)")
+            }
+        }
+    }
+
+    struct TimeSignature: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "time",
+            abstract: "Send a Flex Time Signature message"
+        )
+
+        @Option(name: .long, help: "Group number (0-15).")
+        var group: UInt8 = 0
+
+        @Option(name: .long, help: "Channel number (0-15).")
+        var channel: UInt8?
+
+        @Argument(help: "Numerator")
+        var numerator: UInt8
+
+        @Argument(help: "Denominator (power of two, e.g. 4, 8)")
+        var denominator: UInt8
+
+        func run() throws {
+            guard let g = Uint4(group) else {
+                throw ValidationError("Group out of range")
+            }
+            let address: FlexTimeSignature.Address
+            if let chVal = channel {
+                guard let ch = Uint4(chVal) else {
+                    throw ValidationError("Channel out of range")
+                }
+                address = .channel(group: g, channel: ch)
+            } else {
+                address = .group(g)
+            }
+            guard denominator != 0 && (denominator & (denominator - 1)) == 0 else {
+                throw ValidationError("Denominator must be power of two")
+            }
+            let denomPow2 = UInt8(log2(Double(denominator)))
+            let msg = FlexTimeSignature(address: address, numerator: numerator, denominatorPow2: denomPow2)
+            let packet = msg.encode()
+            print(String(format: "UMP: 0x%08X 0x%08X 0x%08X 0x%08X",
+                         packet.word0, packet.word1, packet.word2, packet.word3))
+            if let decoded = FlexTimeSignature.decode(packet) {
+                let denom = 1 << decoded.denominatorPow2
+                switch decoded.address {
+                case .group(let g):
+                    print("Decoded -> group: \(g.rawValue) meter: \(decoded.numerator)/\(denom)")
+                case .channel(let g, let c):
+                    print("Decoded -> group: \(g.rawValue) channel: \(c.rawValue) meter: \(decoded.numerator)/\(denom)")
+                }
+            }
+        }
+    }
+
+    struct Key: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Send a Flex Key Signature message"
+        )
+
+        @Option(name: .long, help: "Group number (0-15).")
+        var group: UInt8 = 0
+
+        @Option(name: .long, help: "Channel number (0-15).")
+        var channel: UInt8?
+
+        @Argument(help: "Key signature text (e.g. C, Gm)")
+        var key: String
+
+        func run() throws {
+            guard let g = Uint4(group) else {
+                throw ValidationError("Group out of range")
+            }
+            let address: FlexKeySignature.Address
+            if let chVal = channel {
+                guard let ch = Uint4(chVal) else {
+                    throw ValidationError("Channel out of range")
+                }
+                address = .channel(group: g, channel: ch)
+            } else {
+                address = .group(g)
+            }
+            let msg = FlexKeySignature(address: address, key: key)
+            let packet = msg.encode()
+            print(String(format: "UMP: 0x%08X 0x%08X 0x%08X 0x%08X",
+                         packet.word0, packet.word1, packet.word2, packet.word3))
+            if let decoded = FlexKeySignature.decode(packet) {
+                switch decoded.address {
+                case .group(let g):
+                    print("Decoded -> group: \(g.rawValue) key: \(decoded.key)")
+                case .channel(let g, let c):
+                    print("Decoded -> group: \(g.rawValue) channel: \(c.rawValue) key: \(decoded.key)")
+                }
+            }
+        }
+    }
+
+    struct Lyric: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Send a Flex Lyric message"
+        )
+
+        @Option(name: .long, help: "Group number (0-15).")
+        var group: UInt8 = 0
+
+        @Option(name: .long, help: "Channel number (0-15).")
+        var channel: UInt8?
+
+        @Argument(help: "Lyric text")
+        var text: String
+
+        func run() throws {
+            guard let g = Uint4(group) else {
+                throw ValidationError("Group out of range")
+            }
+            let address: FlexLyric.Address
+            if let chVal = channel {
+                guard let ch = Uint4(chVal) else {
+                    throw ValidationError("Channel out of range")
+                }
+                address = .channel(group: g, channel: ch)
+            } else {
+                address = .group(g)
+            }
+            let msg = FlexLyric(address: address, lyric: text)
+            let packet = msg.encode()
+            print(String(format: "UMP: 0x%08X 0x%08X 0x%08X 0x%08X",
+                         packet.word0, packet.word1, packet.word2, packet.word3))
+            if let decoded = FlexLyric.decode(packet) {
+                switch decoded.address {
+                case .group(let g):
+                    print("Decoded -> group: \(g.rawValue) lyric: \(decoded.lyric)")
+                case .channel(let g, let c):
+                    print("Decoded -> group: \(g.rawValue) channel: \(c.rawValue) lyric: \(decoded.lyric)")
+                }
+            }
+        }
+    }
+
+    // Placeholder subcommands for future extensions
+    struct Metronome: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Flex Metronome (not yet implemented)"
+        )
+        func run() throws {
+            print("Metronome command not implemented yet")
+        }
+    }
+
+    struct ChordName: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "chord", abstract: "Flex Chord Name (not yet implemented)")
+        func run() throws {
+            print("ChordName command not implemented yet")
+        }
+    }
+
+    struct Text: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Flex Text (not yet implemented)"
+        )
+        func run() throws {
+            print("Text command not implemented yet")
+        }
+    }
+
+    struct Ruby: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Flex Ruby (not yet implemented)"
+        )
+        func run() throws {
+            print("Ruby command not implemented yet")
+        }
+    }
+}
+

--- a/Sources/midi2demo/main.swift
+++ b/Sources/midi2demo/main.swift
@@ -44,7 +44,7 @@ struct NoteOn: ParsableCommand {
 struct Midi2Demo: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Teaching-oriented MIDI 2.0 demo CLI",
-        subcommands: [NoteOn.self, SysEx7Command.self, SysEx8Command.self]
+        subcommands: [NoteOn.self, SysEx7Command.self, SysEx8Command.self, Flex.self]
     )
 }
 


### PR DESCRIPTION
## Summary
- Add `flex` command with Tempo, TimeSignature, Key, and Lyric subcommands
- Scaffold placeholders for additional Flex Data message types
- Register `flex` with existing demo CLI

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689d7ab81f548333beb42628dd5baec7