### PR TITLE
Add MIDI-CI handshake demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ streaming utilities, MIDI‑CI envelope helpers, and an evolving
 
 ## Status Quo
 
-Active development: core UMP structures and SysEx helpers exist; `midi2demo` CLI currently implements the `note-on`, `sysex7`, and `sysex8` commands. Full spec coverage, additional CLI subcommands, and comprehensive tests remain in progress.
+Active development: core UMP structures and SysEx helpers exist; `midi2demo` CLI currently implements the `note-on`, `sysex7`, `sysex8`, and `ci-handshake` commands. Full spec coverage, additional CLI subcommands, and comprehensive tests remain in progress.
 
 ## Features
 
@@ -21,8 +21,7 @@ Active development: core UMP structures and SysEx helpers exist; `midi2demo` CLI
 ## Roadmap
 
 - Expand implementation to cover the entire MIDI 2.0 specification.
-- Expand the `midi2demo` CLI with streaming, Flex Data, MIDI‑CI handshake,
-  and packet inspection commands.
+- Expand the `midi2demo` CLI with additional streaming, Flex Data, and packet inspection commands.
 - Harden the codebase with additional documentation and integration tests.
 
 ## Installation

--- a/Sources/midi2demo/CIHandshake.swift
+++ b/Sources/midi2demo/CIHandshake.swift
@@ -1,0 +1,51 @@
+import ArgumentParser
+import MIDI2CI
+import Foundation
+
+struct CIHandshakeCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "ci-handshake",
+        abstract: "Simulate MIDI-CI protocol negotiation, profile inquiry, and property exchange."
+    )
+
+    func run() throws {
+        // Protocol negotiation
+        let initiatorSupported: [MidiCIProtocol] = [.midi2, .midi1]
+        let responderSupported: [MidiCIProtocol] = [.midi2]
+
+        let pnRequest = CIHandshake.initiateProtocolNegotiation(supported: initiatorSupported)
+        print("Initiator -> Responder: \(pnRequest)")
+
+        let pnResponse = CIHandshake.respond(to: pnRequest, supported: responderSupported)
+        print("Responder -> Initiator: \(pnResponse)")
+        if let accepted = pnResponse.acceptedProtocol {
+            print("Agreed protocol: \(accepted)")
+        } else {
+            print("No common protocol accepted")
+        }
+
+        // Profile inquiry
+        let profileID = "org.midi.profile.piano"
+        let profileRequest = CIHandshake.initiateProfileInquiry(profile: profileID)
+        print("Initiator -> Responder: \(profileRequest)")
+
+        let profileResponse = CIHandshake.respond(to: profileRequest, supportedProfiles: [profileID])
+        print("Responder -> Initiator: \(profileResponse)")
+        print("Profile \(profileID) supported: \(profileResponse.supported)")
+
+        // Property exchange
+        let resource = "/device/manufacturer"
+        let propertyRequest = CIHandshake.initiatePropertyGet(resource: resource)
+        print("Initiator -> Responder: \(propertyRequest)")
+
+        let properties = [resource: "ACME Corp"]
+        let propertyResponse = CIHandshake.respond(to: propertyRequest, properties: properties)
+        print("Responder -> Initiator: \(propertyResponse)")
+        if let value = propertyResponse.value {
+            print("Property \(resource) value: \(value)")
+        } else {
+            print("Property \(resource) not found")
+        }
+    }
+}
+

--- a/Sources/midi2demo/main.swift
+++ b/Sources/midi2demo/main.swift
@@ -44,7 +44,13 @@ struct NoteOn: ParsableCommand {
 struct Midi2Demo: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Teaching-oriented MIDI 2.0 demo CLI",
-        subcommands: [NoteOn.self, SysEx7Command.self, SysEx8Command.self, Flex.self]
+        subcommands: [
+            NoteOn.self,
+            SysEx7Command.self,
+            SysEx8Command.self,
+            Flex.self,
+            CIHandshakeCommand.self
+        ]
     )
 }
 


### PR DESCRIPTION
## Summary
- add `ci-handshake` subcommand demonstrating protocol negotiation, profile inquiry, and property exchange
- register new command with `Midi2Demo`
- document new command in README status and roadmap

## Testing
- `swift test`
- `swift run midi2demo ci-handshake`

------
https://chatgpt.com/codex/tasks/task_b_689d7c3713c48333a4a97af1fd572d1d