### PR TITLE
Document midi2demo CLI with man page and enriched help

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,17 @@ let package = Package(
     targets: [
         .target(name: "MIDI2"),
         .target(name: "MIDI2CI", dependencies: ["MIDI2"]),
-        .executableTarget(name: "midi2demo", dependencies: [
-            "MIDI2",
-            "MIDI2CI",
-            .product(name: "ArgumentParser", package: "swift-argument-parser")
-        ]),
+        .executableTarget(
+            name: "midi2demo",
+            dependencies: [
+                "MIDI2",
+                "MIDI2CI",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            resources: [
+                .copy("midi2demo.1")
+            ]
+        ),
         .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2", "MIDI2CI"]),
         .testTarget(name: "Fuzz", dependencies: ["MIDI2", "SwiftCheck"], path: "Tests/Fuzz")
     ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ streaming utilities, MIDI‑CI envelope helpers, and an evolving
 
 ## Status Quo
 
-Active development: core UMP structures and SysEx helpers exist; `midi2demo` CLI currently implements the `note-on`, `sysex7`, `sysex8`, `ci-handshake`, and `inspect` commands. Full spec coverage, additional CLI subcommands, and comprehensive tests remain in progress.
+Active development: core UMP structures and SysEx helpers exist; `midi2demo` CLI currently implements the `note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect` commands. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Full spec coverage, additional CLI subcommands, and comprehensive tests remain in progress.
 
 ## Features
 

--- a/Sources/midi2demo/CIHandshake.swift
+++ b/Sources/midi2demo/CIHandshake.swift
@@ -5,7 +5,8 @@ import Foundation
 struct CIHandshakeCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "ci-handshake",
-        abstract: "Simulate MIDI-CI protocol negotiation, profile inquiry, and property exchange."
+        abstract: "Simulate MIDI-CI protocol negotiation, profile inquiry, and property exchange.",
+        discussion: "Runs a scripted interaction showing how MIDI-CI messages are exchanged. No options are required. See midi2demo(1) for background and examples."
     )
 
     func run() throws {

--- a/Sources/midi2demo/Flex.swift
+++ b/Sources/midi2demo/Flex.swift
@@ -6,6 +6,7 @@ struct Flex: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "flex",
         abstract: "Emit Flex Data messages",
+        discussion: "Choose a subcommand to send a specific Flex Data message. See midi2demo(1) for a complete list of messages and examples.",
         subcommands: [
             Tempo.self,
             TimeSignature.self,
@@ -22,7 +23,8 @@ struct Flex: ParsableCommand {
 extension Flex {
     struct Tempo: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Send a Flex Tempo message"
+            abstract: "Send a Flex Tempo message",
+            discussion: "Use --group to choose the destination group and provide the tempo in BPM as an argument. See midi2demo(1) for examples."
         )
 
         @Option(name: .long, help: "Group number (0-15).")
@@ -45,7 +47,8 @@ extension Flex {
     struct TimeSignature: ParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "time",
-            abstract: "Send a Flex Time Signature message"
+            abstract: "Send a Flex Time Signature message",
+            discussion: "Use --group to choose the destination group and optionally --channel. Provide the numerator and denominator as arguments; the denominator must be a power of two. See midi2demo(1) for examples."
         )
 
         @Option(name: .long, help: "Group number (0-15).")
@@ -95,7 +98,8 @@ extension Flex {
 
     struct Key: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Send a Flex Key Signature message"
+            abstract: "Send a Flex Key Signature message",
+            discussion: "Use --group to choose the destination group and optionally --channel. Provide the key signature text (e.g. C, Gm) as an argument. See midi2demo(1) for examples."
         )
 
         @Option(name: .long, help: "Group number (0-15).")
@@ -137,7 +141,8 @@ extension Flex {
 
     struct Lyric: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Send a Flex Lyric message"
+            abstract: "Send a Flex Lyric message",
+            discussion: "Use --group to choose the destination group and optionally --channel. Provide the lyric text as an argument. See midi2demo(1) for examples."
         )
 
         @Option(name: .long, help: "Group number (0-15).")
@@ -180,7 +185,8 @@ extension Flex {
     // Placeholder subcommands for future extensions
     struct Metronome: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Flex Metronome (not yet implemented)"
+            abstract: "Flex Metronome (not yet implemented)",
+            discussion: "Placeholder for future Metronome Flex Data support. See midi2demo(1) for current capabilities."
         )
         func run() throws {
             print("Metronome command not implemented yet")
@@ -189,7 +195,10 @@ extension Flex {
 
     struct ChordName: ParsableCommand {
         static let configuration = CommandConfiguration(
-            commandName: "chord", abstract: "Flex Chord Name (not yet implemented)")
+            commandName: "chord",
+            abstract: "Flex Chord Name (not yet implemented)",
+            discussion: "Placeholder for future Chord Name Flex Data support. See midi2demo(1) for current capabilities."
+        )
         func run() throws {
             print("ChordName command not implemented yet")
         }
@@ -197,7 +206,8 @@ extension Flex {
 
     struct Text: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Flex Text (not yet implemented)"
+            abstract: "Flex Text (not yet implemented)",
+            discussion: "Placeholder for future Text Flex Data support. See midi2demo(1) for current capabilities."
         )
         func run() throws {
             print("Text command not implemented yet")
@@ -206,7 +216,8 @@ extension Flex {
 
     struct Ruby: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Flex Ruby (not yet implemented)"
+            abstract: "Flex Ruby (not yet implemented)",
+            discussion: "Placeholder for future Ruby annotation Flex Data support. See midi2demo(1) for current capabilities."
         )
         func run() throws {
             print("Ruby command not implemented yet")

--- a/Sources/midi2demo/Inspect.swift
+++ b/Sources/midi2demo/Inspect.swift
@@ -5,7 +5,9 @@ import Foundation
 struct InspectCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "inspect",
-        abstract: "Decode a Universal MIDI Packet from hex words.")
+        abstract: "Decode a Universal MIDI Packet from hex words.",
+        discussion: "Provide one, two, or four hexadecimal words representing a 32-, 64-, or 128-bit UMP. The packet is decoded into a human-readable form. See midi2demo(1) for examples."
+    )
 
     @Argument(help: "One or more hex words (8 or 16 digits each)")
     var words: [String]

--- a/Sources/midi2demo/SysEx7.swift
+++ b/Sources/midi2demo/SysEx7.swift
@@ -5,7 +5,8 @@ import Foundation
 struct SysEx7Command: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "sysex7",
-        abstract: "Fragment and reassemble a SysEx7 payload."
+        abstract: "Fragment and reassemble a SysEx7 payload.",
+        discussion: "Specify the target group with --group and the manufacturer ID with --manufacturer using comma-separated hex bytes. Provide the payload as hex bytes or a continuous hex string. See midi2demo(1) for examples."
     )
 
     @Option(name: .long, help: "Group number (0-15).")

--- a/Sources/midi2demo/SysEx8.swift
+++ b/Sources/midi2demo/SysEx8.swift
@@ -5,7 +5,8 @@ import Foundation
 struct SysEx8Command: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "sysex8",
-        abstract: "Fragment and reassemble a SysEx8 payload."
+        abstract: "Fragment and reassemble a SysEx8 payload.",
+        discussion: "Specify the target group with --group and the manufacturer ID with --manufacturer using comma-separated hex bytes. Provide the payload as hex bytes or a continuous hex string. See midi2demo(1) for examples."
     )
 
     @Option(name: .long, help: "Group number (0-15).")

--- a/Sources/midi2demo/main.swift
+++ b/Sources/midi2demo/main.swift
@@ -5,7 +5,8 @@ import MIDI2CI
 struct NoteOn: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "note-on",
-        abstract: "Encode and decode a MIDI 2.0 Note On message."
+        abstract: "Encode and decode a MIDI 2.0 Note On message.",
+        discussion: "Use --group and --channel to target a destination. Provide the note number and velocity as positional arguments. See midi2demo(1) for detailed examples."
     )
 
     @Option(name: [.short, .long], help: "Group number (0-15).")
@@ -44,6 +45,7 @@ struct NoteOn: ParsableCommand {
 struct Midi2Demo: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Teaching-oriented MIDI 2.0 demo CLI",
+        discussion: "Run 'midi2demo <command> --help' for more information. The midi2demo(1) man page provides complete documentation and examples.",
         subcommands: [
             NoteOn.self,
             SysEx7Command.self,

--- a/Sources/midi2demo/midi2demo.1
+++ b/Sources/midi2demo/midi2demo.1
@@ -1,0 +1,72 @@
+.TH midi2demo 1 "April 2024" "MIDI2" "User Commands"
+.SH NAME
+midi2demo \- teaching-oriented MIDI 2.0 demo CLI
+.SH SYNOPSIS
+.B midi2demo
+.I command
+[options] [arguments]
+.SH DESCRIPTION
+.B midi2demo
+exercises the MIDI 2.0 Swift library.  Each subcommand encodes or decodes a
+specific Universal MIDI Packet (UMP) construct.  Run
+.B midi2demo \fIcommand\fR --help
+for option details.  The commands are:
+.TP
+.B note-on
+Encode and decode a MIDI 2.0 Note On message.
+.TP
+.B sysex7
+Fragment and reassemble a 7-bit System Exclusive payload.
+.TP
+.B sysex8
+Fragment and reassemble an 8-bit System Exclusive payload.
+.TP
+.B flex tempo
+Emit a Flex Data tempo message.
+.TP
+.B flex time
+Emit a Flex Data time signature message.
+.TP
+.B flex key
+Emit a Flex Data key signature message.
+.TP
+.B flex lyric
+Emit a Flex Data lyric message.
+.TP
+.B flex metronome
+Placeholder for Flex Data metronome messages.
+.TP
+.B flex chord
+Placeholder for Flex Data chord name messages.
+.TP
+.B flex text
+Placeholder for Flex Data text messages.
+.TP
+.B flex ruby
+Placeholder for Flex Data ruby messages.
+.TP
+.B ci-handshake
+Simulate MIDI-CI protocol negotiation, profile inquiry, and property exchange.
+.TP
+.B inspect
+Decode a Universal MIDI Packet from hexadecimal words.
+.SH EXAMPLES
+Note On for middle C on channel 1 with velocity 100:
+.PP
+.nf
+swift run midi2demo note-on --group 0 --channel 0 60 100
+.fi
+.PP
+SysEx7 payload for a 1-byte manufacturer ID:
+.PP
+.nf
+swift run midi2demo sysex7 --group 0 --manufacturer 7D "01 02 03"
+.fi
+.PP
+Inspect a UMP word:
+.PP
+.nf
+swift run midi2demo inspect 0x40107D00 0x00640000
+.fi
+.SH SEE ALSO
+The project repository includes Swift playgrounds and README examples.


### PR DESCRIPTION
## Summary
- add comprehensive `midi2demo.1` man page with usage examples
- improve all ParsableCommand abstracts and discussions, referencing the man page
- package the man page with the `midi2demo` executable

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689d7ff5784483338aef8c340585b905