### PR TITLE
Improve midi2demo CLI robustness and docs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
                 .copy("midi2demo.1")
             ]
         ),
-        .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2", "MIDI2CI"]),
+        .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2", "MIDI2CI", "midi2demo"]),
         .testTarget(name: "Fuzz", dependencies: ["MIDI2", "SwiftCheck"], path: "Tests/Fuzz")
     ]
 )

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ streaming utilities, MIDI‑CI envelope helpers, and an evolving
 
 ## Status Quo
 
-Active development: core UMP structures and SysEx helpers exist. The `midi2demo` CLI now implements all planned subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. The library adds a schema-aligned `Midi1ChannelVoiceBody` struct for generic MIDI 1 channel voice handling. Full spec coverage and comprehensive tests remain in progress.
+Active development: core UMP structures and SysEx helpers exist. The `midi2demo` CLI now implements all planned subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. The library adds a schema-aligned `Midi1ChannelVoiceBody` struct for generic MIDI 1 channel voice handling. Full spec coverage and comprehensive tests remain in progress.
 
 ## Features
 
@@ -46,11 +46,14 @@ Build and run the teaching-oriented CLI to experiment with MIDI 2.0 messages.
 Examples:
 
 ```bash
-swift run midi2demo note-on 60 100
-swift run midi2demo sysex7 --manufacturer 7D "01 02 03"
-swift run midi2demo sysex8 --manufacturer 00,20,33 "01 02 03 04"
+swift run midi2demo note-on --group 0 --channel 0 60 100
+swift run midi2demo sysex7 --group 0 --manufacturer 7D "01 02 03"
+swift run midi2demo sysex8 --group 0 --manufacturer 00,20,33 "01 02 03 04"
 swift run midi2demo flex tempo --group 0 120
-swift run midi2demo ci-handshake
+swift run midi2demo flex time --group 0 4 4
+swift run midi2demo flex key --group 0 C#m
+swift run midi2demo flex lyric --group 0 "Hello world"
+swift run midi2demo ci-handshake --no-common-protocol --unsupported-profile --missing-property
 swift run midi2demo inspect 0x40107D00 0x00640000
 ```
 

--- a/Sources/midi2demo/CIHandshake.swift
+++ b/Sources/midi2demo/CIHandshake.swift
@@ -6,13 +6,22 @@ struct CIHandshakeCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "ci-handshake",
         abstract: "Simulate MIDI-CI protocol negotiation, profile inquiry, and property exchange.",
-        discussion: "Runs a scripted interaction showing how MIDI-CI messages are exchanged. No options are required. See midi2demo(1) for background and examples."
+        discussion: "Runs a scripted interaction showing how MIDI-CI messages are exchanged. Flags allow simulating failure scenarios. See midi2demo(1) for background and examples."
     )
+
+    @Flag(name: .long, help: "Simulate no common protocol during negotiation")
+    var noCommonProtocol: Bool = false
+
+    @Flag(name: .long, help: "Simulate profile not supported by responder")
+    var unsupportedProfile: Bool = false
+
+    @Flag(name: .long, help: "Simulate missing property value in exchange")
+    var missingProperty: Bool = false
 
     func run() throws {
         // Protocol negotiation
-        let initiatorSupported: [MidiCIProtocol] = [.midi2, .midi1]
-        let responderSupported: [MidiCIProtocol] = [.midi2]
+        let initiatorSupported: [MidiCIProtocol] = noCommonProtocol ? [.midi2] : [.midi2, .midi1]
+        let responderSupported: [MidiCIProtocol] = noCommonProtocol ? [.midi1] : [.midi2]
 
         let pnRequest = CIHandshake.initiateProtocolNegotiation(supported: initiatorSupported)
         print("Initiator -> Responder: \(pnRequest)")
@@ -30,7 +39,7 @@ struct CIHandshakeCommand: ParsableCommand {
         let profileRequest = CIHandshake.initiateProfileInquiry(profile: profileID)
         print("Initiator -> Responder: \(profileRequest)")
 
-        let profileResponse = CIHandshake.respond(to: profileRequest, supportedProfiles: [profileID])
+        let profileResponse = CIHandshake.respond(to: profileRequest, supportedProfiles: unsupportedProfile ? [] : [profileID])
         print("Responder -> Initiator: \(profileResponse)")
         print("Profile \(profileID) supported: \(profileResponse.supported)")
 
@@ -39,7 +48,7 @@ struct CIHandshakeCommand: ParsableCommand {
         let propertyRequest = CIHandshake.initiatePropertyGet(resource: resource)
         print("Initiator -> Responder: \(propertyRequest)")
 
-        let properties = [resource: "ACME Corp"]
+        let properties = missingProperty ? [:] : [resource: "ACME Corp"]
         let propertyResponse = CIHandshake.respond(to: propertyRequest, properties: properties)
         print("Responder -> Initiator: \(propertyResponse)")
         if let value = propertyResponse.value {

--- a/Sources/midi2demo/Flex.swift
+++ b/Sources/midi2demo/Flex.swift
@@ -34,8 +34,14 @@ extension Flex {
         var bpm: Double
 
         func run() throws {
+            guard let g = Uint4(group) else {
+                throw ValidationError("Group out of range")
+            }
+            guard bpm >= 1 else {
+                throw ValidationError("Tempo must be at least 1 BPM")
+            }
             let tempo = FlexDataTempo(beatsPerMinute: bpm)
-            let packet = tempo.encode(group: group)
+            let packet = tempo.encode(group: g.rawValue)
             print(String(format: "UMP: 0x%08X 0x%08X 0x%08X 0x%08X",
                          packet.word0, packet.word1, packet.word2, packet.word3))
             if let decoded = FlexDataTempo.decode(packet) {
@@ -115,6 +121,9 @@ extension Flex {
             guard let g = Uint4(group) else {
                 throw ValidationError("Group out of range")
             }
+            guard !key.isEmpty else {
+                throw ValidationError("Key signature cannot be empty")
+            }
             let address: FlexKeySignature.Address
             if let chVal = channel {
                 guard let ch = Uint4(chVal) else {
@@ -157,6 +166,9 @@ extension Flex {
         func run() throws {
             guard let g = Uint4(group) else {
                 throw ValidationError("Group out of range")
+            }
+            guard !text.isEmpty else {
+                throw ValidationError("Lyric text cannot be empty")
             }
             let address: FlexLyric.Address
             if let chVal = channel {

--- a/Sources/midi2demo/Inspect.swift
+++ b/Sources/midi2demo/Inspect.swift
@@ -13,6 +13,9 @@ struct InspectCommand: ParsableCommand {
     var words: [String]
 
     func run() throws {
+        guard !words.isEmpty else {
+            throw ValidationError("Provide at least one word")
+        }
         let parsedWords = try parse(words: words)
         switch parsedWords.count {
         case 1:

--- a/Sources/midi2demo/SysEx7.swift
+++ b/Sources/midi2demo/SysEx7.swift
@@ -19,13 +19,16 @@ struct SysEx7Command: ParsableCommand {
     var payload: String
 
     func run() throws {
+        guard let g = Uint4(group) else {
+            throw ValidationError("Group out of range")
+        }
         let manufacturerID = try parseManufacturer(manufacturer)
         let payloadBytes = try parsePayload(payload)
 
         let packets = try SysEx7.fragment(
             manufacturerID: manufacturerID,
             payload: payloadBytes,
-            group: group
+            group: g.rawValue
         )
 
         for packet in packets {
@@ -46,6 +49,9 @@ struct SysEx7Command: ParsableCommand {
         guard bytes.count == parts.count else {
             throw ValidationError("Invalid manufacturer ID")
         }
+        guard bytes.count == 1 || bytes.count == 3 else {
+            throw ValidationError("Manufacturer ID must be 1 or 3 bytes")
+        }
         return bytes
     }
 
@@ -58,6 +64,9 @@ struct SysEx7Command: ParsableCommand {
             let bytes = parts.compactMap { UInt8($0, radix: 16) }
             guard bytes.count == parts.count else {
                 throw ValidationError("Invalid payload hex")
+            }
+            guard !bytes.isEmpty else {
+                throw ValidationError("Payload cannot be empty")
             }
             return bytes
         } else {
@@ -75,6 +84,9 @@ struct SysEx7Command: ParsableCommand {
                 }
                 bytes.append(byte)
                 index = next
+            }
+            guard !bytes.isEmpty else {
+                throw ValidationError("Payload cannot be empty")
             }
             return bytes
         }

--- a/Sources/midi2demo/SysEx8.swift
+++ b/Sources/midi2demo/SysEx8.swift
@@ -19,13 +19,16 @@ struct SysEx8Command: ParsableCommand {
     var payload: String
 
     func run() throws {
+        guard let g = Uint4(group) else {
+            throw ValidationError("Group out of range")
+        }
         let manufacturerID = try parseManufacturer(manufacturer)
         let payloadBytes = try parsePayload(payload)
 
         let packets = try SysEx8.fragment(
             manufacturerID: manufacturerID,
             payload: payloadBytes,
-            group: group
+            group: g.rawValue
         )
 
         for packet in packets {
@@ -49,6 +52,9 @@ struct SysEx8Command: ParsableCommand {
         guard bytes.count == parts.count else {
             throw ValidationError("Invalid manufacturer ID")
         }
+        guard bytes.count == 1 || bytes.count == 3 else {
+            throw ValidationError("Manufacturer ID must be 1 or 3 bytes")
+        }
         return bytes
     }
 
@@ -61,6 +67,9 @@ struct SysEx8Command: ParsableCommand {
             let bytes = parts.compactMap { UInt8($0, radix: 16) }
             guard bytes.count == parts.count else {
                 throw ValidationError("Invalid payload hex")
+            }
+            guard !bytes.isEmpty else {
+                throw ValidationError("Payload cannot be empty")
             }
             return bytes
         } else {
@@ -78,6 +87,9 @@ struct SysEx8Command: ParsableCommand {
                 }
                 bytes.append(byte)
                 index = next
+            }
+            guard !bytes.isEmpty else {
+                throw ValidationError("Payload cannot be empty")
             }
             return bytes
         }

--- a/Sources/midi2demo/main.swift
+++ b/Sources/midi2demo/main.swift
@@ -28,6 +28,10 @@ struct NoteOn: ParsableCommand {
             throw ValidationError("Group, channel, or note out of range")
         }
 
+        guard velocity <= UInt16.max else {
+            throw ValidationError("Velocity out of range")
+        }
+
         let message = Midi2NoteOn(
             group: groupVal,
             channel: channelVal,

--- a/Sources/midi2demo/midi2demo.1
+++ b/Sources/midi2demo/midi2demo.1
@@ -47,6 +47,13 @@ Placeholder for Flex Data ruby messages.
 .TP
 .B ci-handshake
 Simulate MIDI-CI protocol negotiation, profile inquiry, and property exchange.
+Flags allow simulating failures:
+.B --no-common-protocol
+forces negotiation to fail,
+.B --unsupported-profile
+forces profile inquiry failure, and
+.B --missing-property
+makes property exchange return no value.
 .TP
 .B inspect
 Decode a Universal MIDI Packet from hexadecimal words.
@@ -61,6 +68,27 @@ SysEx7 payload for a 1-byte manufacturer ID:
 .PP
 .nf
 swift run midi2demo sysex7 --group 0 --manufacturer 7D "01 02 03"
+.fi
+.PP
+SysEx8 payload for a 3-byte manufacturer ID:
+.PP
+.nf
+swift run midi2demo sysex8 --group 0 --manufacturer 00,20,33 "01 02 03 04"
+.fi
+.PP
+Flex Data examples:
+.PP
+.nf
+swift run midi2demo flex tempo --group 0 120
+swift run midi2demo flex time --group 0 4 4
+swift run midi2demo flex key --group 0 C#m
+swift run midi2demo flex lyric --group 0 "Hello world"
+.fi
+.PP
+Run a handshake with failure simulation:
+.PP
+.nf
+swift run midi2demo ci-handshake --no-common-protocol --unsupported-profile --missing-property
 .fi
 .PP
 Inspect a UMP word:

--- a/Tests/MIDI2Tests/Midi2DemoCLITests.swift
+++ b/Tests/MIDI2Tests/Midi2DemoCLITests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import midi2demo
+
+final class Midi2DemoCLITests: XCTestCase {
+    func testNoteOnInvalidGroup() {
+        XCTAssertThrowsError(try NoteOn.parse(["--group", "16", "--channel", "0", "60", "100"]).run())
+    }
+
+    func testSysEx7InvalidManufacturer() {
+        XCTAssertThrowsError(try SysEx7Command.parse(["--manufacturer", "GG", "00"]).run())
+    }
+
+    func testSysEx8GroupOutOfRange() {
+        XCTAssertThrowsError(try SysEx8Command.parse(["--group", "16", "--manufacturer", "00", "01"]).run())
+    }
+
+    func testFlexTempoNegative() {
+        XCTAssertThrowsError(try Flex.Tempo.parse(["--group", "0", "0.5"]).run())
+    }
+
+    func testFlexTimeSignatureBadDenominator() {
+        XCTAssertThrowsError(try Flex.TimeSignature.parse(["--group", "0", "4", "3"]).run())
+    }
+
+    func testFlexKeyEmpty() {
+        XCTAssertThrowsError(try Flex.Key.parse(["--group", "0", ""]).run())
+    }
+
+    func testFlexLyricEmpty() {
+        XCTAssertThrowsError(try Flex.Lyric.parse(["--group", "0", ""]).run())
+    }
+
+    func testInspectInvalidWord() {
+        XCTAssertThrowsError(try InspectCommand.parse(["ZZ"]).run())
+    }
+
+    func testCIHandshakeFlags() {
+        XCTAssertNoThrow(try CIHandshakeCommand.parse(["--no-common-protocol", "--unsupported-profile", "--missing-property"]).run())
+    }
+}


### PR DESCRIPTION
## Summary
- Harden midi2demo subcommands with range and empty-input validation
- Add flags to simulate failure paths in `ci-handshake`
- Document and test all CLI subcommands with examples and man page updates

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689d8e6890ac83338981f4ff7d8b6fe1