### PR TITLE
Add jitter reduction tests and demo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
     products: [
         .library(name: "MIDI2", targets: ["MIDI2"]),
         .library(name: "MIDI2CI", targets: ["MIDI2CI"]),
-        .executable(name: "midi2demo", targets: ["midi2demo"])
+        .executable(name: "midi2demo", targets: ["midi2demo"]),
+        .executable(name: "jitterdemo", targets: ["jitterdemo"])
     ],
     dependencies: [
         .package(url: "https://github.com/typelift/SwiftCheck.git", from: "0.12.0"),
@@ -29,6 +30,7 @@ let package = Package(
                 .copy("midi2demo.1")
             ]
         ),
+        .executableTarget(name: "jitterdemo", dependencies: ["MIDI2"]),
         .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2", "MIDI2CI", "midi2demo"]),
         .testTarget(name: "Fuzz", dependencies: ["MIDI2", "SwiftCheck"], path: "Tests/Fuzz")
     ]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ $LLVM_COV report .build/x86_64-unknown-linux-gnu/debug/MIDI2PackageTests.xctest 
   --instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata
 ```
 
+## Jitter Reduction
+
+MIDI 2.0 introduces Jitter Reduction (JR) Clock and Timestamp messages to
+preserve precise scheduling over links that may introduce transmission
+variation. The library exposes these as `Utility.jrClock` and
+`Utility.jrTimestamp`, which encode 16‑bit values representing a sender’s
+timebase and per‑message offsets for jitter‑corrected playback.
+
+Run the demo executable to observe the packets and their reconstructed times:
+
+```bash
+swift run jitterdemo
+```
+
+For background on the JR mechanism, see the MIDI 2.0 Universal MIDI Packet
+specification (Section 4, “Jitter Reduction (JR) Clock and Timestamps”) in
+`M2-104-UM_v1-1-2_UMP_and_MIDI_2-0_Protocol_Specification.pdf`.
+
 ## Examples
 
 See the `Examples/` directory for Swift Playgrounds demonstrating common tasks:

--- a/Sources/jitterdemo/main.swift
+++ b/Sources/jitterdemo/main.swift
@@ -1,0 +1,27 @@
+import Foundation
+import MIDI2
+
+@main
+struct JitterDemo {
+    static func main() {
+        let period: UInt16 = 1000 // arbitrary units
+        var clock: UInt16 = 0
+
+        for cycle in 0..<3 {
+            let clockMsg = Utility.jrClock(clock)
+            let clockWord = clockMsg.ump().word
+            print("cycle \(cycle) clock 0x\(String(clock, radix:16)) ->", String(format: "%08X", clockWord))
+
+            for offset in [UInt16(10), UInt16(50)] {
+                usleep(useconds_t(UInt32.random(in: 0...5000)))
+                let tsMsg = Utility.jrTimestamp(offset)
+                let abs = clock &+ offset
+                let tsWord = tsMsg.ump().word
+                print("  event offset \(offset) abs \(abs) ->", String(format: "%08X", tsWord))
+            }
+
+            clock &+= period
+            usleep(useconds_t(period))
+        }
+    }
+}

--- a/Tests/MIDI2Tests/System/JitterReductionTests.swift
+++ b/Tests/MIDI2Tests/System/JitterReductionTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import MIDI2
+
+final class JitterReductionTests: XCTestCase {
+    func testInterleavedClockAndTimestamp() {
+        let sequence: [Utility] = [
+            .jrClock(0x1000),
+            .jrTimestamp(0x0010),
+            .jrTimestamp(0x0020),
+            .jrClock(0x2000),
+            .jrTimestamp(0x0005)
+        ]
+
+        var base: UInt32 = 0
+        var reconstructed: [UInt32] = []
+        for msg in sequence {
+            switch msg {
+            case .jrClock(let value):
+                base = UInt32(value)
+            case .jrTimestamp(let value):
+                reconstructed.append(base + UInt32(value))
+            default:
+                XCTFail("unexpected message")
+            }
+        }
+
+        XCTAssertEqual(reconstructed, [0x1010, 0x1020, 0x2005])
+    }
+}

--- a/Tests/MIDI2Tests/System/UtilityTests.swift
+++ b/Tests/MIDI2Tests/System/UtilityTests.swift
@@ -9,6 +9,13 @@ final class UtilityTests: XCTestCase {
         XCTAssertEqual(decoded, msg)
     }
 
+    func testRoundTripJRTimestamp() {
+        let msg = Utility.jrTimestamp(0x2345)
+        let ump = msg.ump()
+        let decoded = Utility(ump: ump)
+        XCTAssertEqual(decoded, msg)
+    }
+
     func testMalformedGroupNibble() {
         // group nibble must be zero for utility messages
         let byte0 = UInt32(0x0 << 4 | 0x1) // mt=0, group=1 -> invalid

--- a/Tests/MIDI2Tests/UtilityBodyTests.swift
+++ b/Tests/MIDI2Tests/UtilityBodyTests.swift
@@ -11,4 +11,14 @@ final class UtilityBodyTests: XCTestCase {
         // throwing variant
         XCTAssertNoThrow(try UtilityBody(parsingUMP: packet))
     }
+
+    func testRoundTripJRTimestamp() throws {
+        let body = UtilityBody(opcode: .jrTimestamp, value: 0x2345)
+        let packet = body.ump()
+        let decoded = UtilityBody(ump: packet)
+        XCTAssertEqual(decoded, body)
+
+        // throwing variant
+        XCTAssertNoThrow(try UtilityBody(parsingUMP: packet))
+    }
 }


### PR DESCRIPTION
## Summary
- expand Utility jitter coverage with round-trip tests for jrTimestamp
- verify interleaved jrClock/jrTimestamp scheduling in new tests
- add `jitterdemo` executable and docs demonstrating jitter reduction

## Testing
- `swift test`
- `swift run jitterdemo`

------
https://chatgpt.com/codex/tasks/task_b_689ead0e7f288333b0c602ed249ab9a1