### PR TITLE
Scaffold Apple Core MIDI bridge package with timing utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Introduced `TeatroAppleBridge` package scaffolding with grid and clock helpers for Apple Core MIDI integration.
+
 ## [0.2.0] - 2025-08-14
 ### Added
 - Full implementation of the MIDI 2.0 specification.

--- a/Packages/TeatroAppleBridge/Package.swift
+++ b/Packages/TeatroAppleBridge/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "TeatroAppleBridge",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "TeatroAppleBridge", targets: ["TeatroAppleBridge"])
+    ],
+    targets: [
+        .target(name: "TeatroAppleBridge"),
+        .testTarget(name: "TeatroAppleBridgeTests", dependencies: ["TeatroAppleBridge"])
+    ]
+)

--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleMIDIBridge.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleMIDIBridge.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Identifies a destination by matching its name and desired protocol.
+public struct MIDIDestinationSelector {
+    /// Substring that should appear in the destination name.
+    public var matchContains: String
+    /// UMP group (0-15) to transmit on.
+    public var group: UInt8
+    /// Preferred MIDI protocol version.
+    public var `protocol`: MIDIProtocolID
+
+    /// Creates a new destination selector.
+    /// - Parameters:
+    ///   - matchContains: Substring to match in destination names.
+    ///   - group: UMP group number.
+    ///   - protocol: Preferred protocol; defaults to MIDI 2.0.
+    public init(matchContains: String, group: UInt8 = 0, protocol midiProtocol: MIDIProtocolID = ._2_0) {
+        self.matchContains = matchContains
+        self.group = group
+        self.`protocol` = midiProtocol
+    }
+}
+
+/// Represents the MIDI protocol version used for communication.
+public enum MIDIProtocolID: UInt8 {
+    /// MIDI 1.0 over Universal MIDI Packets.
+    case _1_0 = 1
+    /// Native MIDI 2.0.
+    case _2_0 = 2
+}
+
+/// Bridge for sending UMP messages through Core MIDI destinations.
+///
+/// The implementation is a placeholder; full Core MIDI integration is
+/// provided on Apple platforms in future work.
+public final class AppleMIDIBridge {
+    /// Creates a new bridge instance.
+    public init(clientName: String = "TeatroClient") throws {}
+
+    /// Selects a MIDI destination matching the provided selector.
+    public func selectDestination(_ selector: MIDIDestinationSelector) throws {}
+
+    /// Sends raw UMP words to the selected destination.
+    public func sendUMP(words: [UInt32], hostTime: UInt64) throws {}
+
+    /// Convenience method to send a Control Change message.
+    public func sendCC(channel: UInt8, cc: UInt8, value: UInt8,
+                       group: UInt8 = 0, hostTime: UInt64) throws {}
+
+    /// Convenience method to send a Note On message.
+    public func sendNoteOn(channel: UInt8, note: UInt8, velocity: UInt16,
+                           group: UInt8 = 0, hostTime: UInt64) throws {}
+
+    /// Convenience method to send a Note Off message.
+    public func sendNoteOff(channel: UInt8, note: UInt8, velocity: UInt16,
+                            group: UInt8 = 0, hostTime: UInt64) throws {}
+
+    /// Starts a virtual MIDI source that other applications can subscribe to.
+    public func startVirtualSource(name: String, protocol midiProtocol: MIDIProtocolID) throws {}
+
+    /// Publishes UMP words through the virtual source.
+    public func publishUMP(words: [UInt32], hostTime: UInt64) throws {}
+}

--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleMIDIReceiver.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleMIDIReceiver.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Receives UMP messages from Core MIDI inputs and forwards them to a handler.
+///
+/// This is a stub implementation that will be expanded with real Core MIDI
+/// receive blocks on Apple platforms.
+public final class AppleMIDIReceiver {
+    /// Callback invoked when UMP words arrive.
+    public typealias Handler = (_ group: UInt8, _ words: [UInt32], _ hostTime: UInt64) -> Void
+
+    /// Creates a receiver instance.
+    public init(clientName: String = "TeatroClient") throws {}
+
+    /// Opens an input port matching the provided name.
+    public func openInput(nameMatch: String, protocol midiProtocol: MIDIProtocolID,
+                          handler: @escaping Handler) throws {}
+}

--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleSequencerBridge.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleSequencerBridge.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Represents a tempo change at a given beat position.
+public struct TempoEvent {
+    /// Beat position where the tempo change occurs.
+    public let beat: Double
+    /// Beats per minute at the specified beat.
+    public let bpm: Double
+
+    /// Creates a tempo event.
+    public init(beat: Double, bpm: Double) {
+        self.beat = beat
+        self.bpm = bpm
+    }
+}
+
+/// Time signature represented as numerator and denominator power-of-two.
+public struct TimeSignature {
+    /// Numerator of the time signature.
+    public let numerator: UInt8
+    /// Denominator expressed as power of two (e.g. 4/4 → 2).
+    public let denominatorPow2: UInt8
+
+    /// Creates a time signature.
+    public init(numerator: UInt8, denominatorPow2: UInt8) {
+        self.numerator = numerator
+        self.denominatorPow2 = denominatorPow2
+    }
+}
+
+/// Builds MusicSequence structures and exports Standard MIDI Files.
+///
+/// The current implementation provides API stubs to be filled in with Core
+/// MIDI sequencing calls on Apple platforms.
+public final class AppleSequencerBridge {
+    /// Creates a bridge with the desired pulses-per-quarter-note and signature.
+    public init(ppq: Int = 480,
+                timeSignature: TimeSignature = .init(numerator: 4, denominatorPow2: 2)) {}
+
+    /// Sets the tempo map.
+    public func setTempoMap(_ events: [TempoEvent]) {}
+
+    /// Adds a marker at the specified beat.
+    public func addMarker(beat: Double, text: String) {}
+
+    /// Adds a lyric event at the specified beat.
+    public func addLyric(beat: Double, text: String) {}
+
+    /// Adds a note event to the sequence.
+    public func addNote(track: Int, channel: UInt8, note: UInt8, velocity: UInt8,
+                        startBeat: Double, durationBeats: Double) {}
+
+    /// Exports the sequence to a Standard MIDI File.
+    public func exportSMF(url: URL) throws {}
+}

--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/GridTime.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/GridTime.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Utilities for converting between grid-based musical time and beats/seconds.
+public enum GridTime {
+    /// Converts a bar:beat:tick position into total beats.
+    /// - Parameters:
+    ///   - bar: Bar number starting at 1.
+    ///   - beat: Beat number within the bar starting at 1.
+    ///   - tick: Tick offset within the beat.
+    ///   - beatsPerBar: Number of beats in each bar.
+    ///   - ticksPerBeat: Tick resolution per beat.
+    /// - Returns: Total beats from the beginning of the piece.
+    public static func barBeatTickToBeats(bar: Int, beat: Int, tick: Int,
+                                          beatsPerBar: Int, ticksPerBeat: Int) -> Double {
+        let barBeats = Double((bar - 1) * beatsPerBar)
+        let beatBeats = Double(beat - 1)
+        let tickBeats = Double(tick) / Double(ticksPerBeat)
+        return barBeats + beatBeats + tickBeats
+    }
+
+    /// Converts beats to seconds given a tempo in BPM.
+    /// - Parameters:
+    ///   - beats: Number of beats.
+    ///   - tempoBPM: Tempo in beats per minute.
+    /// - Returns: Duration in seconds.
+    public static func beatsToSeconds(_ beats: Double, tempoBPM: Double) -> Double {
+        beats * 60.0 / tempoBPM
+    }
+}

--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/MIDIClock.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/MIDIClock.swift
@@ -1,0 +1,23 @@
+import Foundation
+#if canImport(Dispatch)
+import Dispatch
+#endif
+
+/// Helpers for working with host time on Apple platforms.
+public enum MIDIClock {
+    /// Returns the current host time in nanoseconds.
+    public static func nowHostTime() -> UInt64 {
+        #if canImport(Dispatch)
+        return DispatchTime.now().uptimeNanoseconds
+        #else
+        return UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
+        #endif
+    }
+
+    /// Converts seconds into host time units.
+    /// - Parameter seconds: Duration in seconds.
+    /// - Returns: Equivalent host time in nanoseconds.
+    public static func secondsToHostTime(_ seconds: Double) -> UInt64 {
+        UInt64(seconds * 1_000_000_000)
+    }
+}

--- a/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/ReceiverTests.swift
+++ b/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/ReceiverTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import TeatroAppleBridge
+
+final class ReceiverTests: XCTestCase {
+    func testPlaceholder() throws {
+        // Placeholder test; real receiver tests will parse UMP streams.
+        XCTAssertTrue(true)
+    }
+}

--- a/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/SenderTests.swift
+++ b/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/SenderTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import TeatroAppleBridge
+
+final class SenderTests: XCTestCase {
+    func testPlaceholder() throws {
+        // Placeholder test; real sender tests will exercise Core MIDI scheduling.
+        XCTAssertTrue(true)
+    }
+}

--- a/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/SequencerTests.swift
+++ b/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/SequencerTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import TeatroAppleBridge
+
+final class SequencerTests: XCTestCase {
+    func testGridTimeAndClock() {
+        let beats = GridTime.barBeatTickToBeats(bar: 2, beat: 1, tick: 240,
+                                                beatsPerBar: 4, ticksPerBeat: 480)
+        XCTAssertEqual(beats, 4.5, accuracy: 0.0001)
+
+        let seconds = GridTime.beatsToSeconds(4.0, tempoBPM: 120.0)
+        XCTAssertEqual(seconds, 2.0, accuracy: 0.0001)
+
+        let host = MIDIClock.secondsToHostTime(seconds)
+        XCTAssertEqual(Double(host) / 1_000_000_000, seconds, accuracy: 0.0001)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ streaming utilities, MIDI‑CI envelope helpers, and a teaching‑oriented
 
 ## Status
 
-The library now implements the entire MIDI 2.0 specification and is tagged for its first stable release, 0.2.0, ready for consumption via Swift Package Manager. The `midi2demo` CLI covers all subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Integration tests spawn the `midi2demo` executable to exercise success and failure paths for every subcommand.
+The library now implements the entire MIDI 2.0 specification and is tagged for its first stable release, 0.2.0, ready for consumption via Swift Package Manager. The `midi2demo` CLI covers all subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Integration tests spawn the `midi2demo` executable to exercise success and failure paths for every subcommand. Initial scaffolding for an Apple-native Core MIDI adapter (`TeatroAppleBridge`) is now included.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- set up `TeatroAppleBridge` Swift package scaffold targeting macOS
- stub out Apple MIDIBridge, receiver, sequencer, and timing helpers
- add placeholder tests and update README and changelog

## Testing
- `swift test`
- `(cd Packages/TeatroAppleBridge && swift test)`

------
https://chatgpt.com/codex/tasks/task_b_689f2b1b801083339c2ca37f3248dae8