### PR TITLE
Implement virtual Core MIDI bridge and sequencer utilities

### DIFF
--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleMIDIBridge.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleMIDIBridge.swift
@@ -34,30 +34,85 @@ public enum MIDIProtocolID: UInt8 {
 /// The implementation is a placeholder; full Core MIDI integration is
 /// provided on Apple platforms in future work.
 public final class AppleMIDIBridge {
+    /// Bridge‑specific errors.
+    public enum BridgeError: Error {
+        case destinationNotFound
+        case noDestinationSelected
+        case virtualSourceNotStarted
+    }
+
+    private let clientName: String
+    private var destinationName: String?
+    private var virtualSourceName: String?
+
+    /// Records events for unit tests.
+    public private(set) var sentEvents: [(group: UInt8, words: [UInt32], hostTime: UInt64)] = []
+
     /// Creates a new bridge instance.
-    public init(clientName: String = "TeatroClient") throws {}
+    public init(clientName: String = "TeatroClient") throws {
+        self.clientName = clientName
+    }
 
     /// Selects a MIDI destination matching the provided selector.
-    public func selectDestination(_ selector: MIDIDestinationSelector) throws {}
+    public func selectDestination(_ selector: MIDIDestinationSelector) throws {
+        guard let name = VirtualMIDIRouter.sourceName(matching: selector.matchContains) else {
+            throw BridgeError.destinationNotFound
+        }
+        destinationName = name
+    }
 
     /// Sends raw UMP words to the selected destination.
-    public func sendUMP(words: [UInt32], hostTime: UInt64) throws {}
+    public func sendUMP(words: [UInt32], hostTime: UInt64) throws {
+        guard let name = destinationName else {
+            throw BridgeError.noDestinationSelected
+        }
+        let group = UInt8((words.first ?? 0) >> 24 & 0x0F)
+        sentEvents.append((group, words, hostTime))
+        VirtualMIDIRouter.publish(name: name, group: group, words: words, hostTime: hostTime)
+    }
 
     /// Convenience method to send a Control Change message.
     public func sendCC(channel: UInt8, cc: UInt8, value: UInt8,
-                       group: UInt8 = 0, hostTime: UInt64) throws {}
+                       group: UInt8 = 0, hostTime: UInt64) throws {
+        let status: UInt32 = 0xB0 | UInt32(channel & 0x0F)
+        let word: UInt32 = (0x2 << 28) | (UInt32(group & 0x0F) << 24)
+            | (status << 16) | (UInt32(cc & 0x7F) << 8) | UInt32(value & 0x7F)
+        try sendUMP(words: [word], hostTime: hostTime)
+    }
 
     /// Convenience method to send a Note On message.
     public func sendNoteOn(channel: UInt8, note: UInt8, velocity: UInt16,
-                           group: UInt8 = 0, hostTime: UInt64) throws {}
+                           group: UInt8 = 0, hostTime: UInt64) throws {
+        let vel = UInt32(min(velocity, 0x7F))
+        let status: UInt32 = 0x90 | UInt32(channel & 0x0F)
+        let word: UInt32 = (0x2 << 28) | (UInt32(group & 0x0F) << 24)
+            | (status << 16) | (UInt32(note & 0x7F) << 8) | vel
+        try sendUMP(words: [word], hostTime: hostTime)
+    }
 
     /// Convenience method to send a Note Off message.
     public func sendNoteOff(channel: UInt8, note: UInt8, velocity: UInt16,
-                            group: UInt8 = 0, hostTime: UInt64) throws {}
+                            group: UInt8 = 0, hostTime: UInt64) throws {
+        let vel = UInt32(min(velocity, 0x7F))
+        let status: UInt32 = 0x80 | UInt32(channel & 0x0F)
+        let word: UInt32 = (0x2 << 28) | (UInt32(group & 0x0F) << 24)
+            | (status << 16) | (UInt32(note & 0x7F) << 8) | vel
+        try sendUMP(words: [word], hostTime: hostTime)
+    }
 
     /// Starts a virtual MIDI source that other applications can subscribe to.
-    public func startVirtualSource(name: String, protocol midiProtocol: MIDIProtocolID) throws {}
+    public func startVirtualSource(name: String, protocol midiProtocol: MIDIProtocolID) throws {
+        virtualSourceName = name
+        VirtualMIDIRouter.registerSource(name: name)
+    }
 
     /// Publishes UMP words through the virtual source.
-    public func publishUMP(words: [UInt32], hostTime: UInt64) throws {}
+    public func publishUMP(words: [UInt32], hostTime: UInt64) throws {
+        guard let name = virtualSourceName else {
+            throw BridgeError.virtualSourceNotStarted
+        }
+        let group = UInt8((words.first ?? 0) >> 24 & 0x0F)
+        sentEvents.append((group, words, hostTime))
+        VirtualMIDIRouter.publish(name: name, group: group, words: words, hostTime: hostTime)
+    }
 }

--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleMIDIReceiver.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleMIDIReceiver.swift
@@ -2,16 +2,27 @@ import Foundation
 
 /// Receives UMP messages from Core MIDI inputs and forwards them to a handler.
 ///
-/// This is a stub implementation that will be expanded with real Core MIDI
-/// receive blocks on Apple platforms.
+/// The real implementation would hook into Core MIDI's receive blocks. For
+/// cross‑platform testing we simulate inputs via ``VirtualMIDIRouter``.
 public final class AppleMIDIReceiver {
     /// Callback invoked when UMP words arrive.
-    public typealias Handler = (_ group: UInt8, _ words: [UInt32], _ hostTime: UInt64) -> Void
+    public typealias Handler = @Sendable (_ group: UInt8, _ words: [UInt32], _ hostTime: UInt64) -> Void
+
+    /// Errors that can be thrown by the receiver.
+    public enum ReceiverError: Error { case inputNotFound }
+
+    private let clientName: String
 
     /// Creates a receiver instance.
-    public init(clientName: String = "TeatroClient") throws {}
+    public init(clientName: String = "TeatroClient") throws {
+        self.clientName = clientName
+    }
 
     /// Opens an input port matching the provided name.
     public func openInput(nameMatch: String, protocol midiProtocol: MIDIProtocolID,
-                          handler: @escaping Handler) throws {}
+                          handler: @escaping Handler) throws {
+        guard VirtualMIDIRouter.subscribe(nameMatch: nameMatch, handler: handler) else {
+            throw ReceiverError.inputNotFound
+        }
+    }
 }

--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleSequencerBridge.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/AppleSequencerBridge.swift
@@ -30,26 +30,138 @@ public struct TimeSignature {
 
 /// Builds MusicSequence structures and exports Standard MIDI Files.
 ///
-/// The current implementation provides API stubs to be filled in with Core
-/// MIDI sequencing calls on Apple platforms.
+/// This lightweight implementation collects events in memory and writes a
+/// minimal Standard MIDI File (format 0) for use in unit tests. The focus is on
+/// deterministic translation from beat‑based positions to MIDI ticks.
 public final class AppleSequencerBridge {
+    private let ppq: Int
+    private let timeSignature: TimeSignature
+
+    private var tempoMap: [TempoEvent] = []
+    private var markers: [(beat: Double, text: String)] = []
+    private var lyrics: [(beat: Double, text: String)] = []
+    private struct Note { let track: Int; let channel: UInt8; let note: UInt8; let velocity: UInt8; let start: Double; let duration: Double }
+    private var notes: [Note] = []
+
     /// Creates a bridge with the desired pulses-per-quarter-note and signature.
     public init(ppq: Int = 480,
-                timeSignature: TimeSignature = .init(numerator: 4, denominatorPow2: 2)) {}
+                timeSignature: TimeSignature = .init(numerator: 4, denominatorPow2: 2)) {
+        self.ppq = ppq
+        self.timeSignature = timeSignature
+    }
 
     /// Sets the tempo map.
-    public func setTempoMap(_ events: [TempoEvent]) {}
+    public func setTempoMap(_ events: [TempoEvent]) {
+        tempoMap = events.sorted { $0.beat < $1.beat }
+    }
 
     /// Adds a marker at the specified beat.
-    public func addMarker(beat: Double, text: String) {}
+    public func addMarker(beat: Double, text: String) {
+        markers.append((beat, text))
+    }
 
     /// Adds a lyric event at the specified beat.
-    public func addLyric(beat: Double, text: String) {}
+    public func addLyric(beat: Double, text: String) {
+        lyrics.append((beat, text))
+    }
 
     /// Adds a note event to the sequence.
     public func addNote(track: Int, channel: UInt8, note: UInt8, velocity: UInt8,
-                        startBeat: Double, durationBeats: Double) {}
+                        startBeat: Double, durationBeats: Double) {
+        notes.append(Note(track: track, channel: channel, note: note, velocity: velocity,
+                          start: startBeat, duration: durationBeats))
+    }
+
+    /// Converts beats to absolute ticks using the configured PPQ.
+    private func ticks(fromBeats beats: Double) -> Int {
+        Int(round(beats * Double(ppq)))
+    }
+
+    /// Encodes an integer into a variable-length quantity.
+    private func vlq(_ value: Int) -> [UInt8] {
+        var buffer = value & 0x7F
+        var result: [UInt8] = [UInt8(buffer)]
+        var value = value >> 7
+        while value > 0 {
+            buffer = value & 0x7F
+            value >>= 7
+            result.insert(UInt8(buffer | 0x80), at: 0)
+        }
+        return result
+    }
 
     /// Exports the sequence to a Standard MIDI File.
-    public func exportSMF(url: URL) throws {}
+    public func exportSMF(url: URL) throws {
+        var events: [(tick: Int, data: [UInt8])] = []
+
+        // Tempo events
+        for t in tempoMap {
+            let usPerQuarter = Int(60_000_000 / t.bpm)
+            let data: [UInt8] = [0xFF, 0x51, 0x03,
+                                 UInt8((usPerQuarter >> 16) & 0xFF),
+                                 UInt8((usPerQuarter >> 8) & 0xFF),
+                                 UInt8(usPerQuarter & 0xFF)]
+            events.append((tick: ticks(fromBeats: t.beat), data: data))
+        }
+
+        // Time signature at start
+        let tsData: [UInt8] = [0xFF, 0x58, 0x04,
+                               timeSignature.numerator,
+                               timeSignature.denominatorPow2,
+                               24, 8]
+        events.append((tick: 0, data: tsData))
+
+        // Markers and lyrics
+        for m in markers {
+            let bytes = Array(m.text.utf8)
+            let data: [UInt8] = [0xFF, 0x06] + vlq(bytes.count) + bytes
+            events.append((tick: ticks(fromBeats: m.beat), data: data))
+        }
+        for l in lyrics {
+            let bytes = Array(l.text.utf8)
+            let data: [UInt8] = [0xFF, 0x05] + vlq(bytes.count) + bytes
+            events.append((tick: ticks(fromBeats: l.beat), data: data))
+        }
+
+        // Notes
+        for n in notes {
+            let start = ticks(fromBeats: n.start)
+            let end = ticks(fromBeats: n.start + n.duration)
+            events.append((tick: start, data: [0x90 | (n.channel & 0x0F), n.note, n.velocity]))
+            events.append((tick: end, data: [0x80 | (n.channel & 0x0F), n.note, 0]))
+        }
+
+        // Sort by tick
+        events.sort { $0.tick < $1.tick }
+
+        // Build track data with delta times
+        var trackBytes: [UInt8] = []
+        var lastTick = 0
+        for event in events {
+            let delta = event.tick - lastTick
+            lastTick = event.tick
+            trackBytes += vlq(delta)
+            trackBytes += event.data
+        }
+        // End-of-track
+        trackBytes += [0x00, 0xFF, 0x2F, 0x00]
+
+        // Header chunk
+        var fileBytes: [UInt8] = []
+        fileBytes += Array("MThd".utf8)
+        fileBytes += [0x00, 0x00, 0x00, 0x06]
+        fileBytes += [0x00, 0x00] // format 0
+        fileBytes += [0x00, 0x01] // one track
+        fileBytes += [UInt8((ppq >> 8) & 0xFF), UInt8(ppq & 0xFF)]
+
+        // Track chunk
+        fileBytes += Array("MTrk".utf8)
+        let length = UInt32(trackBytes.count)
+        fileBytes += [UInt8((length >> 24) & 0xFF), UInt8((length >> 16) & 0xFF),
+                      UInt8((length >> 8) & 0xFF), UInt8(length & 0xFF)]
+        fileBytes += trackBytes
+
+        let data = Data(fileBytes)
+        try data.write(to: url)
+    }
 }

--- a/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/VirtualMIDIRouter.swift
+++ b/Packages/TeatroAppleBridge/Sources/TeatroAppleBridge/VirtualMIDIRouter.swift
@@ -1,0 +1,73 @@
+import Foundation
+#if canImport(Dispatch)
+import Dispatch
+#endif
+
+/// Internal router connecting virtual sources to receivers within tests.
+///
+/// This emulates Core MIDI's virtual connections in a lightweight,
+/// cross‑platform manner so the package can be tested on non‑Apple
+/// platforms. Each virtual source is identified by name; receivers may
+/// subscribe using a substring match. Published UMP messages are delivered
+/// to all subscribed handlers.
+struct VirtualMIDIRouter {
+    typealias Handler = @Sendable (_ group: UInt8, _ words: [UInt32], _ hostTime: UInt64) -> Void
+
+    #if canImport(Dispatch)
+    private static let queue = DispatchQueue(label: "VirtualMIDIRouterQueue")
+    #endif
+    nonisolated(unsafe) private static var sources: [String: [Handler]] = [:]
+
+    /// Registers a new virtual source by name.
+    static func registerSource(name: String) {
+        #if canImport(Dispatch)
+        queue.sync {
+            sources[name] = sources[name] ?? []
+        }
+        #else
+        sources[name] = sources[name] ?? []
+        #endif
+    }
+
+    /// Returns the first source name that contains the given substring.
+    static func sourceName(matching substring: String) -> String? {
+        #if canImport(Dispatch)
+        return queue.sync {
+            sources.keys.first { $0.contains(substring) }
+        }
+        #else
+        return sources.keys.first { $0.contains(substring) }
+        #endif
+    }
+
+    /// Subscribes a handler to the first source whose name contains the
+    /// provided substring.
+    /// - Returns: Boolean indicating whether a source was found.
+    static func subscribe(nameMatch: String, handler: @escaping Handler) -> Bool {
+        #if canImport(Dispatch)
+        return queue.sync {
+            guard let name = sources.keys.first(where: { $0.contains(nameMatch) }) else { return false }
+            sources[name, default: []].append(handler)
+            return true
+        }
+        #else
+        guard let name = sources.keys.first(where: { $0.contains(nameMatch) }) else { return false }
+        sources[name, default: []].append(handler)
+        return true
+        #endif
+    }
+
+    /// Publishes UMP words to all handlers registered for the named source.
+    static func publish(name: String, group: UInt8, words: [UInt32], hostTime: UInt64) {
+        let handlers: [Handler]
+        #if canImport(Dispatch)
+        handlers = queue.sync { sources[name] ?? [] }
+        #else
+        handlers = sources[name] ?? []
+        #endif
+        for handler in handlers {
+            handler(group, words, hostTime)
+        }
+    }
+}
+

--- a/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/ReceiverTests.swift
+++ b/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/ReceiverTests.swift
@@ -2,8 +2,19 @@ import XCTest
 @testable import TeatroAppleBridge
 
 final class ReceiverTests: XCTestCase {
-    func testPlaceholder() throws {
-        // Placeholder test; real receiver tests will parse UMP streams.
-        XCTAssertTrue(true)
+    func testVirtualSourceReceivesUMP() throws {
+        let bridge = try AppleMIDIBridge()
+        try bridge.startVirtualSource(name: "Loop", protocol: ._1_0)
+
+        let recvExpectation = expectation(description: "received")
+        let receiver = try AppleMIDIReceiver()
+        try receiver.openInput(nameMatch: "Loop", protocol: ._1_0) { group, words, _ in
+            XCTAssertEqual(group, 0)
+            XCTAssertEqual(words[0], 0x20093C64)
+            recvExpectation.fulfill()
+        }
+
+        try bridge.publishUMP(words: [0x20093C64], hostTime: 1234)
+        wait(for: [recvExpectation], timeout: 1.0)
     }
 }

--- a/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/SenderTests.swift
+++ b/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/SenderTests.swift
@@ -2,8 +2,19 @@ import XCTest
 @testable import TeatroAppleBridge
 
 final class SenderTests: XCTestCase {
-    func testPlaceholder() throws {
-        // Placeholder test; real sender tests will exercise Core MIDI scheduling.
-        XCTAssertTrue(true)
+    func testSendConvenienceBuildsUMP() throws {
+        let bridge = try AppleMIDIBridge()
+        try bridge.startVirtualSource(name: "TestDest", protocol: ._1_0)
+        try bridge.selectDestination(.init(matchContains: "TestDest", group: 0, protocol: ._1_0))
+
+        let t = MIDIClock.nowHostTime()
+        try bridge.sendCC(channel: 1, cc: 7, value: 64, group: 0, hostTime: t)
+        try bridge.sendNoteOn(channel: 2, note: 60, velocity: 100, group: 0, hostTime: t)
+        try bridge.sendNoteOff(channel: 2, note: 60, velocity: 0, group: 0, hostTime: t)
+
+        XCTAssertEqual(bridge.sentEvents.count, 3)
+        XCTAssertEqual(bridge.sentEvents[0].words[0], 0x20B10740)
+        XCTAssertEqual(bridge.sentEvents[1].words[0], 0x20923C64)
+        XCTAssertEqual(bridge.sentEvents[2].words[0], 0x20823C00)
     }
 }

--- a/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/SequencerTests.swift
+++ b/Packages/TeatroAppleBridge/Tests/TeatroAppleBridgeTests/SequencerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Foundation
 @testable import TeatroAppleBridge
 
 final class SequencerTests: XCTestCase {
@@ -12,5 +13,19 @@ final class SequencerTests: XCTestCase {
 
         let host = MIDIClock.secondsToHostTime(seconds)
         XCTAssertEqual(Double(host) / 1_000_000_000, seconds, accuracy: 0.0001)
+    }
+
+    func testExportSMFWritesData() throws {
+        let seq = AppleSequencerBridge()
+        seq.setTempoMap([TempoEvent(beat: 0, bpm: 120)])
+        seq.addMarker(beat: 0, text: "Start")
+        seq.addLyric(beat: 1, text: "La")
+        seq.addNote(track: 0, channel: 0, note: 60, velocity: 100,
+                    startBeat: 0, durationBeats: 1)
+
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test.mid")
+        try seq.exportSMF(url: url)
+        let data = try Data(contentsOf: url)
+        XCTAssertGreaterThan(data.count, 0)
     }
 }


### PR DESCRIPTION
## Summary
- add AppleMIDIBridge with convenience CC/note send and virtual source support
- implement AppleMIDIReceiver and simple MusicSequence exporter
- introduce in-memory virtual MIDI router and tests for sending, receiving, and SMF export

## Testing
- `swift test --package-path Packages/TeatroAppleBridge`

------
https://chatgpt.com/codex/tasks/task_b_689f2d154680833387a9a19181ed4b37