### PR TITLE
Add Apple bridge demos and docs

### DIFF
--- a/Examples/SendCCDemo/Package.swift
+++ b/Examples/SendCCDemo/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "SendCCDemo",
+    platforms: [ .macOS(.v13) ],
+    dependencies: [
+        .package(path: "../../Packages/TeatroAppleBridge")
+    ],
+    targets: [
+        .executableTarget(
+            name: "SendCCDemo",
+            dependencies: [
+                .product(name: "TeatroAppleBridge", package: "TeatroAppleBridge")
+            ])
+    ]
+)

--- a/Examples/SendCCDemo/Sources/SendCCDemo/main.swift
+++ b/Examples/SendCCDemo/Sources/SendCCDemo/main.swift
@@ -1,0 +1,17 @@
+import TeatroAppleBridge
+
+// Send a few Control Change and Note On/Off events to a virtual destination.
+let bridge = try AppleMIDIBridge()
+try bridge.startVirtualSource(name: "SendDest", protocol: ._1_0)
+try bridge.selectDestination(.init(matchContains: "SendDest", group: 0, protocol: ._1_0))
+
+let start = MIDIClock.nowHostTime()
+for i in 0..<8 {
+    let t = MIDIClock.secondsToHostTime(Double(i) * 0.1) + start
+    try bridge.sendCC(channel: 0, cc: 7, value: UInt8(i * 16), group: 0, hostTime: t)
+}
+let noteTime = MIDIClock.secondsToHostTime(1.0) + start
+try bridge.sendNoteOn(channel: 0, note: 60, velocity: 100, group: 0, hostTime: noteTime)
+try bridge.sendNoteOff(channel: 0, note: 60, velocity: 0, group: 0, hostTime: noteTime + MIDIClock.secondsToHostTime(0.5))
+
+print("Sent", bridge.sentEvents.count, "events")

--- a/Examples/SequenceExportDemo/Package.swift
+++ b/Examples/SequenceExportDemo/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "SequenceExportDemo",
+    platforms: [ .macOS(.v13) ],
+    dependencies: [
+        .package(path: "../../Packages/TeatroAppleBridge")
+    ],
+    targets: [
+        .executableTarget(
+            name: "SequenceExportDemo",
+            dependencies: [
+                .product(name: "TeatroAppleBridge", package: "TeatroAppleBridge")
+            ])
+    ]
+)

--- a/Examples/SequenceExportDemo/Sources/SequenceExportDemo/main.swift
+++ b/Examples/SequenceExportDemo/Sources/SequenceExportDemo/main.swift
@@ -1,0 +1,14 @@
+import Foundation
+import TeatroAppleBridge
+
+// Build a simple sequence and write it to disk.
+let seq = AppleSequencerBridge()
+seq.setTempoMap([TempoEvent(beat: 0, bpm: 120)])
+seq.addMarker(beat: 0, text: "Start")
+seq.addLyric(beat: 1, text: "La")
+seq.addNote(track: 0, channel: 0, note: 60, velocity: 100,
+            startBeat: 0, durationBeats: 1)
+
+let url = URL(fileURLWithPath: "demo.mid")
+try seq.exportSMF(url: url)
+print("Wrote", url.path)

--- a/Examples/VirtualSourceDemo/Package.swift
+++ b/Examples/VirtualSourceDemo/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "VirtualSourceDemo",
+    platforms: [ .macOS(.v13) ],
+    dependencies: [
+        .package(path: "../../Packages/TeatroAppleBridge")
+    ],
+    targets: [
+        .executableTarget(
+            name: "VirtualSourceDemo",
+            dependencies: [
+                .product(name: "TeatroAppleBridge", package: "TeatroAppleBridge")
+            ])
+    ]
+)

--- a/Examples/VirtualSourceDemo/Sources/VirtualSourceDemo/main.swift
+++ b/Examples/VirtualSourceDemo/Sources/VirtualSourceDemo/main.swift
@@ -1,0 +1,18 @@
+import Foundation
+import TeatroAppleBridge
+
+// Publish a virtual source and echo any events received.
+let bridge = try AppleMIDIBridge()
+try bridge.startVirtualSource(name: "EchoSource", protocol: ._1_0)
+
+let receiver = try AppleMIDIReceiver()
+try receiver.openInput(nameMatch: "EchoSource", protocol: ._1_0) { group, words, hostTime in
+    print("group", group, "words", words.map { String(format: "0x%08X", $0) }, "time", hostTime)
+}
+
+// Publish a test note to trigger the echo path.
+let now = MIDIClock.nowHostTime()
+try bridge.publishUMP(words: [0x20903C64], hostTime: now)
+
+// Keep alive briefly so async callbacks can fire.
+Thread.sleep(forTimeInterval: 1.0)

--- a/Packages/TeatroAppleBridge/README.md
+++ b/Packages/TeatroAppleBridge/README.md
@@ -1,0 +1,38 @@
+# TeatroAppleBridge
+
+Adapter package that bridges the `midi2` Universal MIDI Packet model to
+Apple's Core MIDI and MusicSequence APIs.
+
+The implementation provided here is a lightweight, cross‑platform stub
+that mirrors Core MIDI behavior so the package can be built and tested on
+Linux. On Apple platforms the same API can be backed by the native Core
+MIDI calls.
+
+## Modules
+
+- ``AppleMIDIBridge`` – discover destinations, send UMP words, or publish a
+  virtual source.
+- ``AppleMIDIReceiver`` – open an input and receive UMP words via a handler
+  callback.
+- ``AppleSequencerBridge`` – build a tempo map, add markers/lyrics/notes and
+  export a Standard MIDI File.
+- ``GridTime`` and ``MIDIClock`` – helper utilities for grid conversions and
+  host‑time calculations.
+
+## Example
+
+```swift
+import TeatroAppleBridge
+
+let bridge = try AppleMIDIBridge()
+try bridge.startVirtualSource(name: "DemoDest", protocol: ._1_0)
+try bridge.selectDestination(.init(matchContains: "DemoDest"))
+
+let start = MIDIClock.nowHostTime()
+try bridge.sendCC(channel: 0, cc: 21, value: 64,
+                  group: 0, hostTime: start)
+```
+
+The example sends a single Control Change message through a virtual
+connection using the stubbed router. Replace the virtual hooks with real
+Core MIDI calls when running on macOS.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ streaming utilities, MIDI‑CI envelope helpers, and a teaching‑oriented
 
 ## Status
 
-The library now implements the entire MIDI 2.0 specification and is tagged for its first stable release, 0.2.0, ready for consumption via Swift Package Manager. The `midi2demo` CLI covers all subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Integration tests spawn the `midi2demo` executable to exercise success and failure paths for every subcommand. Initial scaffolding for an Apple-native Core MIDI adapter (`TeatroAppleBridge`) is now included.
+The library now implements the entire MIDI 2.0 specification and is tagged for its first stable release, 0.2.0, ready for consumption via Swift Package Manager. The `midi2demo` CLI covers all subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Integration tests spawn the `midi2demo` executable to exercise success and failure paths for every subcommand. A cross-platform `TeatroAppleBridge` package now offers a Core MIDI–style API with unit tests and command-line demos.
 
 ## Features
 
@@ -98,6 +98,22 @@ $LLVM_COV report .build/x86_64-unknown-linux-gnu/debug/MIDI2PackageTests.xctest 
   --instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata
 ```
 
+## TeatroAppleBridge (Core MIDI adapter)
+
+`TeatroAppleBridge` is a small package that bridges the library's Universal MIDI
+Packet model to Apple's Core MIDI and MusicSequence APIs. It exposes
+`AppleMIDIBridge` for sending or publishing UMP, `AppleMIDIReceiver` for
+receiving via a handler block, and `AppleSequencerBridge` for offline sequence
+export.
+
+### Demos
+
+The `Examples/` folder contains command-line demos:
+
+- `SendCCDemo` – send CC ramps and a note burst to a destination.
+- `VirtualSourceDemo` – publish a virtual source and echo incoming events.
+- `SequenceExportDemo` – build a sequence and write a `.mid` file.
+
 ## Jitter Reduction
 
 MIDI 2.0 introduces Jitter Reduction (JR) Clock and Timestamp messages to
@@ -126,6 +142,12 @@ See the `Examples/` directory for Swift Playgrounds demonstrating common tasks:
 - [Mixed Data Set chunk transfer](Examples/MDS.playground)
 - [Flex tempo message](Examples/FlexTiming.playground)
 - [MIDI-CI handshake](Examples/MIDICIHandshake.playground)
+
+CLI demos built with `TeatroAppleBridge`:
+
+- [SendCCDemo](Examples/SendCCDemo)
+- [VirtualSourceDemo](Examples/VirtualSourceDemo)
+- [SequenceExportDemo](Examples/SequenceExportDemo)
 
 ### Encoding a Channel Voice Message
 


### PR DESCRIPTION
## Summary
- document the TeatroAppleBridge package and its modules
- add SendCCDemo, VirtualSourceDemo, and SequenceExportDemo command-line examples
- mention the new bridge and demos in the main README

## Testing
- `swift test --package-path Packages/TeatroAppleBridge`
- `swift test`
- `swift build --package-path Examples/SendCCDemo`
- `swift build --package-path Examples/VirtualSourceDemo`
- `swift build --package-path Examples/SequenceExportDemo`
- `swiftformat --lint .` *(fails: command not found)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f37323d348333aa3c957ff2a30367