### PR TITLE
chore: prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+## [0.3.0] - 2025-08-15
 ### Added
-- Introduced `TeatroAppleBridge` package scaffolding with grid and clock helpers for Apple Core MIDI integration.
+- Completed `TeatroAppleBridge` Core MIDI adapter with sender, receiver, and sequencer APIs plus grid/clock utilities.
+- Added command-line demos and unit tests for the Apple bridge components.
 
 ## [0.2.0] - 2025-08-14
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version: 6.1
 import PackageDescription
 
-let packageVersion = "0.2.0"
+let packageVersion = "0.3.0"
 
 let package = Package(
     name: "MIDI2",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ streaming utilities, MIDI‑CI envelope helpers, and a teaching‑oriented
 
 ## Status
 
-The library now implements the entire MIDI 2.0 specification and is tagged for its first stable release, 0.2.0, ready for consumption via Swift Package Manager. The `midi2demo` CLI covers all subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Integration tests spawn the `midi2demo` executable to exercise success and failure paths for every subcommand. A cross-platform `TeatroAppleBridge` package now offers a Core MIDI–style API with unit tests and command-line demos.
+The library implements the entire MIDI 2.0 specification and now ships with the `TeatroAppleBridge` Core MIDI adapter, accompanying command-line demos, and unit tests. Version 0.3.0 is ready for consumption via Swift Package Manager. The `midi2demo` CLI covers all subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Integration tests spawn the `midi2demo` executable to exercise success and failure paths for every subcommand.
 
 ## Features
 
@@ -31,7 +31,7 @@ Add `MIDI2` to your project using the [Swift Package Manager](https://www.swift.
 
 ```swift
 dependencies: [
-    .package(url: "https://example.com/midi2.git", from: "0.2.0")
+    .package(url: "https://example.com/midi2.git", from: "0.3.0")
 ]
 ```
 


### PR DESCRIPTION
## Summary
- release 0.3.0 with completed TeatroAppleBridge Core MIDI adapter
- update README and install instructions for new version
- bump package version to 0.3.0

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689f3b7ad49083338c2de65176da76ff