### PR TITLE
feat(sb): semantic browser & dissector (swift-only, cli-first)

### DIFF
--- a/sb/Package.swift
+++ b/sb/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "SemanticBrowser",
+    platforms: [
+        .macOS(.v15)
+    ],
+    products: [
+        .executable(name: "sb", targets: ["SBCLI"]),
+        .library(name: "SBCore", targets: ["SBCore"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "SBCore", path: "Sources/SBCore"),
+        .executableTarget(name: "SBCLI", dependencies: ["SBCore"], path: "Sources/SBCLI"),
+        .testTarget(name: "SBTests", dependencies: ["SBCore"], path: "Tests/SBTests")
+    ]
+)

--- a/sb/README.md
+++ b/sb/README.md
@@ -1,0 +1,5 @@
+# Semantic Browser & Dissector
+
+A Swift 6.1 workspace for browsing web pages via the Chrome DevTools Protocol and performing semantic analysis.
+
+This package is scaffolded as part of the Codex runbook.

--- a/sb/Sources/SBCLI/Commands/AnalyzeCommand.swift
+++ b/sb/Sources/SBCLI/Commands/AnalyzeCommand.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct AnalyzeCommand {
+    // TODO: implement analyze logic
+}

--- a/sb/Sources/SBCLI/Commands/BrowseCommand.swift
+++ b/sb/Sources/SBCLI/Commands/BrowseCommand.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct BrowseCommand {
+    // TODO: implement browse logic
+}

--- a/sb/Sources/SBCLI/Commands/IndexCommand.swift
+++ b/sb/Sources/SBCLI/Commands/IndexCommand.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct IndexCommand {
+    // TODO: implement index logic
+}

--- a/sb/Sources/SBCLI/main.swift
+++ b/sb/Sources/SBCLI/main.swift
@@ -1,0 +1,4 @@
+import SBCore
+import Foundation
+
+print("Semantic Browser CLI placeholder")

--- a/sb/Sources/SBCore/Models/Analysis.swift
+++ b/sb/Sources/SBCore/Models/Analysis.swift
@@ -1,0 +1,3 @@
+public struct Analysis: Codable, Sendable {
+    public init() {}
+}

--- a/sb/Sources/SBCore/Models/Blocks.swift
+++ b/sb/Sources/SBCore/Models/Blocks.swift
@@ -1,0 +1,3 @@
+public struct Block: Codable, Sendable {
+    public init() {}
+}

--- a/sb/Sources/SBCore/Models/Claims.swift
+++ b/sb/Sources/SBCore/Models/Claims.swift
@@ -1,0 +1,3 @@
+public struct Claim: Codable, Sendable {
+    public init() {}
+}

--- a/sb/Sources/SBCore/Models/Entities.swift
+++ b/sb/Sources/SBCore/Models/Entities.swift
@@ -1,0 +1,3 @@
+public struct Entity: Codable, Sendable {
+    public init() {}
+}

--- a/sb/Sources/SBCore/Models/IndexDocs.swift
+++ b/sb/Sources/SBCore/Models/IndexDocs.swift
@@ -1,0 +1,10 @@
+public struct IndexOptions: Sendable {
+    public var enabled: Bool
+    public init(enabled: Bool = false) {
+        self.enabled = enabled
+    }
+}
+
+public struct IndexResult: Codable, Sendable {
+    public init() {}
+}

--- a/sb/Sources/SBCore/Models/Snapshot.swift
+++ b/sb/Sources/SBCore/Models/Snapshot.swift
@@ -1,0 +1,3 @@
+public struct Snapshot: Codable, Sendable {
+    public init() {}
+}

--- a/sb/Sources/SBCore/Models/WaitPolicy.swift
+++ b/sb/Sources/SBCore/Models/WaitPolicy.swift
@@ -1,0 +1,7 @@
+public enum WaitPolicy: Sendable {
+    case domContentLoaded
+}
+
+public enum DissectionMode: Sendable {
+    case quick
+}

--- a/sb/Sources/SBCore/Pipeline/Orchestrator.swift
+++ b/sb/Sources/SBCore/Pipeline/Orchestrator.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public struct Orchestrator {
+    public init() {}
+}

--- a/sb/Sources/SBCore/Ports/ArtifactStore.swift
+++ b/sb/Sources/SBCore/Ports/ArtifactStore.swift
@@ -1,0 +1,5 @@
+public protocol ArtifactStore: Sendable {
+    func writeSnapshot(_ snap: Snapshot) async throws
+    func writeAnalysis(_ analysis: Analysis) async throws
+    func readSnapshot(id: String) async throws -> Snapshot?
+}

--- a/sb/Sources/SBCore/Ports/Dissecting.swift
+++ b/sb/Sources/SBCore/Ports/Dissecting.swift
@@ -1,0 +1,3 @@
+public protocol Dissecting: Sendable {
+    func analyze(from snapshot: Snapshot, mode: DissectionMode, store: ArtifactStore?) async throws -> Analysis
+}

--- a/sb/Sources/SBCore/Ports/Indexing.swift
+++ b/sb/Sources/SBCore/Ports/Indexing.swift
@@ -1,0 +1,3 @@
+public protocol Indexing: Sendable {
+    func upsert(analysis: Analysis, options: IndexOptions) async throws -> IndexResult
+}

--- a/sb/Sources/SBCore/Ports/Navigating.swift
+++ b/sb/Sources/SBCore/Ports/Navigating.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol Navigating: Sendable {
+    func snapshot(url: URL, wait: WaitPolicy, store: ArtifactStore?) async throws -> Snapshot
+}

--- a/sb/Sources/SBCore/SB.swift
+++ b/sb/Sources/SBCore/SB.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public actor SB {
+    public let navigator: any Navigating
+    public let dissector: any Dissecting
+    public let indexer: any Indexing
+    public let store: ArtifactStore?
+
+    public init(navigator: any Navigating, dissector: any Dissecting, indexer: any Indexing, store: ArtifactStore?) {
+        self.navigator = navigator
+        self.dissector = dissector
+        self.indexer = indexer
+        self.store = store
+    }
+
+    public func browseAndDissect(url: URL, wait: WaitPolicy, mode: DissectionMode, index: IndexOptions?) async throws -> (Snapshot, Analysis?, IndexResult?) {
+        let snap = try await navigator.snapshot(url: url, wait: wait, store: store)
+        let analysis = try await dissector.analyze(from: snap, mode: mode, store: store)
+        let res = (index?.enabled ?? false) ? try await indexer.upsert(analysis: analysis, options: index!) : nil
+        return (snap, analysis, res)
+    }
+}

--- a/sb/Tests/SBTests/SBTests.swift
+++ b/sb/Tests/SBTests/SBTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import Foundation
+@testable import SBCore
+
+struct DummyNavigator: Navigating {
+    func snapshot(url: URL, wait: WaitPolicy, store: ArtifactStore?) async throws -> Snapshot {
+        Snapshot()
+    }
+}
+
+struct DummyDissector: Dissecting {
+    func analyze(from snapshot: Snapshot, mode: DissectionMode, store: ArtifactStore?) async throws -> Analysis {
+        Analysis()
+    }
+}
+
+struct DummyIndexer: Indexing {
+    func upsert(analysis: Analysis, options: IndexOptions) async throws -> IndexResult {
+        IndexResult()
+    }
+}
+
+final class SBTests: XCTestCase {
+    func testBrowseAndDissect() async throws {
+        let sb = SB(navigator: DummyNavigator(), dissector: DummyDissector(), indexer: DummyIndexer(), store: nil)
+        let (snap, analysis, res) = try await sb.browseAndDissect(url: URL(string: "https://example.com")!, wait: .domContentLoaded, mode: .quick, index: IndexOptions())
+        XCTAssertNotNil(snap)
+        XCTAssertNotNil(analysis)
+        XCTAssertNil(res)
+    }
+}

--- a/sb/agent.md
+++ b/sb/agent.md
@@ -1,0 +1,3 @@
+# Codex Agent: Semantic Browser & Dissector (Swift-only)
+
+This workspace follows the Codex delivery runbook. It contains initial scaffolding for the Semantic Browser project.


### PR DESCRIPTION
## Summary
- scaffold Semantic Browser Swift package with CLI and core library
- define SB actor, ports, models, and placeholder commands
- add basic async test for browse-and-dissect pipeline

## Testing
- `swift test`
- `(cd sb && swift test)`

------
https://chatgpt.com/codex/tasks/task_b_689f6580125c8333bd6196af57fac42f