### PR TITLE
refactor: isolate jitterdemo entry point

### DIFF
--- a/Sources/jitterdemo/main.swift
+++ b/Sources/jitterdemo/main.swift
@@ -3,7 +3,7 @@ import MIDI2
 
 @main
 struct JitterDemo {
-    static func main() {
+    static func main() throws {
         let period: UInt16 = 1000 // arbitrary units
         var clock: UInt16 = 0
 


### PR DESCRIPTION
## Summary
- centralize jitterdemo logic under a throwing @main entry point

## Testing
- `swift package resolve`
- `swift build -v`
- `swift test --parallel`


------
https://chatgpt.com/codex/tasks/task_b_68a0088908948333a16eba33deadda2b