### PR TITLE
Make jitterdemo concurrency-safe with async entry

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,17 @@ let package = Package(
                 .copy("midi2demo.1")
             ]
         ),
-        .executableTarget(name: "jitterdemo", dependencies: ["MIDI2"]),
+        .executableTarget(
+            name: "jitterdemo",
+            dependencies: ["MIDI2"],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-strict-concurrency=complete",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-warn-concurrency"
+                ], .when(configuration: .debug))
+            ]
+        ),
         .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2", "MIDI2CI", "midi2demo"]),
         .testTarget(name: "Fuzz", dependencies: ["MIDI2", "SwiftCheck"], path: "Tests/Fuzz")
     ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ streaming utilities, MIDI‑CI envelope helpers, and a teaching‑oriented
 
 ## Status
 
-The library implements the entire MIDI 2.0 specification and now ships with the `TeatroAppleBridge` Core MIDI adapter, accompanying command-line demos, and unit tests. Version 0.3.0 is ready for consumption via Swift Package Manager. The `midi2demo` CLI covers all subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Integration tests spawn the `midi2demo` executable to exercise success and failure paths for every subcommand.
+The library implements the entire MIDI 2.0 specification and now ships with the `TeatroAppleBridge` Core MIDI adapter, accompanying command-line demos, and unit tests. Version 0.3.0 is ready for consumption via Swift Package Manager. The `midi2demo` CLI covers all subcommands—`note-on`, `sysex7`, `sysex8`, `flex` (tempo, time signature, key, lyric), `ci-handshake`, and `inspect`—with validation for edge cases and options to simulate MIDI-CI failures. A `midi2demo.1` man page and enhanced `--help` output accompany the tool. Integration tests spawn the `midi2demo` executable to exercise success and failure paths for every subcommand. The `jitterdemo` sample now builds with Swift 6.1 strict concurrency and actor data race checks.
 
 ## Features
 

--- a/Sources/jitterdemo/JitterApp.swift
+++ b/Sources/jitterdemo/JitterApp.swift
@@ -1,19 +1,20 @@
 import Foundation
 import MIDI2
 
-@main
-struct JitterDemo {
-    static func main() throws {
-        let period: UInt16 = 1000 // arbitrary units
+/// Actor responsible for running the jitter demonstration.
+actor JitterApp {
+    func run() async throws {
+        let period: UInt16 = 1000 // microseconds
         var clock: UInt16 = 0
 
         for cycle in 0..<3 {
             let clockMsg = Utility.jrClock(clock)
             let clockWord = clockMsg.ump().word
-            print("cycle \(cycle) clock 0x\(String(clock, radix:16)) ->", String(format: "%08X", clockWord))
+            print("cycle \(cycle) clock 0x\(String(clock, radix: 16)) ->", String(format: "%08X", clockWord))
 
             for offset in [UInt16(10), UInt16(50)] {
-                usleep(useconds_t(UInt32.random(in: 0...5000)))
+                let delay = UInt64(UInt32.random(in: 0...5000)) * 1_000 // microseconds → nanoseconds
+                try await Task.sleep(nanoseconds: delay)
                 let tsMsg = Utility.jrTimestamp(offset)
                 let abs = clock &+ offset
                 let tsWord = tsMsg.ump().word
@@ -21,7 +22,7 @@ struct JitterDemo {
             }
 
             clock &+= period
-            usleep(useconds_t(period))
+            try await Task.sleep(nanoseconds: UInt64(period) * 1_000) // microseconds → nanoseconds
         }
     }
 }

--- a/Sources/jitterdemo/JitterDemoMain.swift
+++ b/Sources/jitterdemo/JitterDemoMain.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@main
+struct JitterDemo {
+  /// Single, explicit async entry point (no top-level execution elsewhere).
+  @MainActor
+  static func main() async {
+    do {
+      // Construct only Sendable/actor-safe values here.
+      let app = JitterApp()
+      try await app.run()
+    } catch {
+      let message = "jitterdemo failed: \(error)\n"
+      if let data = message.data(using: .utf8) {
+        do {
+          try FileHandle.standardError.write(contentsOf: data)
+        } catch {
+          // intentionally ignore stderr write failures
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce `JitterApp` actor and async `@main` entry point for jitterdemo
- Enable Swift 6.1 strict-concurrency and actor data race checks in Package manifest
- Document strict-concurrency build in README status

## Testing
- `swift package resolve`
- `swift build -v`
- `swift test --parallel`


------
https://chatgpt.com/codex/tasks/task_b_68a00bacfb00833381f06e964082f6ef