### PR TITLE
Add swift-numerics for macOS toolchain compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b9b38bec4a7260fed5e2683496e72d8859dd8eda05dba5e1c440603228fd459e",
+  "originHash" : "e69115b27dc4d0cbb5af89268ecbe98b3a448d48d0fde16422dad0f10e3102da",
   "pins" : [
     {
       "identity" : "chalk",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
         "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/typelift/SwiftCheck.git", from: "0.12.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.1")
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.1"),
+        .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.0")
     ],
     targets: [
-        .target(name: "MIDI2"),
+        .target(name: "MIDI2", dependencies: [.product(name: "Numerics", package: "swift-numerics")]),
         .target(name: "MIDI2CI", dependencies: ["MIDI2"]),
         .executableTarget(
             name: "midi2demo",


### PR DESCRIPTION
## Summary
- add swift-numerics dependency to the package
- link Numerics product in the MIDI2 target for macOS toolchain builds

## Testing
- `swift build -v`
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_b_68b036c8074c8333965d428f9c4f4fe5