### PR TITLE
feat: harden flex validation and muid lifecycle

### DIFF
--- a/Sources/MIDI2/FlexChordName.swift
+++ b/Sources/MIDI2/FlexChordName.swift
@@ -13,7 +13,11 @@ public struct FlexChordName: Equatable {
     public var chord: String
 
     /// Creates a chord name message.
-    public init(address: Address, chord: String) {
+    public init(address: Address, chord: String) throws {
+        let length = chord.utf8.count
+        guard length <= 12 else {
+            throw MIDIError.valueOutOfRange(name: "chord", value: UInt64(length), range: 0...12)
+        }
         self.address = address
         self.chord = chord
     }
@@ -91,7 +95,6 @@ public struct FlexChordName: Equatable {
 
         let strBytes = bytes.prefix { $0 != 0 }
         let chord = String(bytes: strBytes, encoding: .utf8) ?? ""
-        return FlexChordName(address: address, chord: chord)
+        return try? FlexChordName(address: address, chord: chord)
     }
 }
-

--- a/Sources/MIDI2/FlexDataTempo.swift
+++ b/Sources/MIDI2/FlexDataTempo.swift
@@ -6,12 +6,16 @@ public struct FlexDataTempo: Equatable {
         guard beatsPerMinute >= 1 else {
             throw MIDIError.valueOutOfRange(name: "beatsPerMinute", value: UInt64(beatsPerMinute), range: 1...UInt64.max)
         }
+        guard beatsPerMinute <= Self.maxBeatsPerMinute else {
+            throw MIDIError.valueOutOfRange(name: "beatsPerMinute", value: UInt64(beatsPerMinute), range: 1...UInt64(Self.maxBeatsPerMinute))
+        }
         self.beatsPerMinute = beatsPerMinute
     }
 
     private static let statusClass: UInt8 = 0x10
     private static let status: UInt8 = 0x01
     private static let scale: Double = 65536.0 // 16.16 fixed point
+    private static let maxBeatsPerMinute: Double = Double(UInt32.max) / scale
 
     private var fixedPointValue: UInt32 {
         UInt32((beatsPerMinute * Self.scale).rounded())
@@ -31,6 +35,7 @@ public struct FlexDataTempo: Equatable {
               UInt8((packet.word0 >> 16) & 0xFF) == statusClass,
               UInt8((packet.word0 >> 8) & 0xFF) == status else { return nil }
         let bpm = Double(packet.word1) / scale
+        guard bpm >= 1, bpm <= maxBeatsPerMinute else { return nil }
         return try? FlexDataTempo(beatsPerMinute: bpm)
     }
 }

--- a/Sources/MIDI2/FlexKeySignature.swift
+++ b/Sources/MIDI2/FlexKeySignature.swift
@@ -13,7 +13,11 @@ public struct FlexKeySignature: Equatable {
     public var key: String
 
     /// Creates a key signature message.
-    public init(address: Address, key: String) {
+    public init(address: Address, key: String) throws {
+        let length = key.utf8.count
+        guard length <= 12 else {
+            throw MIDIError.valueOutOfRange(name: "key", value: UInt64(length), range: 0...12)
+        }
         self.address = address
         self.key = key
     }
@@ -91,7 +95,6 @@ public struct FlexKeySignature: Equatable {
 
         let strBytes = bytes.prefix { $0 != 0 }
         let key = String(bytes: strBytes, encoding: .utf8) ?? ""
-        return FlexKeySignature(address: address, key: key)
+        return try? FlexKeySignature(address: address, key: key)
     }
 }
-

--- a/Sources/MIDI2/FlexLyric.swift
+++ b/Sources/MIDI2/FlexLyric.swift
@@ -13,7 +13,11 @@ public struct FlexLyric: Equatable {
     public var lyric: String
 
     /// Creates a lyric message.
-    public init(address: Address, lyric: String) {
+    public init(address: Address, lyric: String) throws {
+        let length = lyric.utf8.count
+        guard length <= 12 else {
+            throw MIDIError.valueOutOfRange(name: "lyric", value: UInt64(length), range: 0...12)
+        }
         self.address = address
         self.lyric = lyric
     }
@@ -91,7 +95,6 @@ public struct FlexLyric: Equatable {
 
         let strBytes = bytes.prefix { $0 != 0 }
         let lyric = String(bytes: strBytes, encoding: .utf8) ?? ""
-        return FlexLyric(address: address, lyric: lyric)
+        return try? FlexLyric(address: address, lyric: lyric)
     }
 }
-

--- a/Sources/MIDI2/FlexMetronome.swift
+++ b/Sources/MIDI2/FlexMetronome.swift
@@ -20,6 +20,10 @@ public struct FlexMetronome: Equatable {
         guard clicksPerBeat >= 1 else {
             throw MIDIError.valueOutOfRange(name: "clicksPerBeat", value: UInt64(clicksPerBeat), range: 1...UInt64.max)
         }
+        let patternLength = accentPattern.utf8.count
+        guard patternLength <= 10 else {
+            throw MIDIError.valueOutOfRange(name: "accentPattern", value: UInt64(patternLength), range: 0...10)
+        }
         self.address = address
         self.clicksPerBeat = clicksPerBeat
         self.accentPattern = accentPattern

--- a/Sources/MIDI2/FlexRuby.swift
+++ b/Sources/MIDI2/FlexRuby.swift
@@ -13,7 +13,11 @@ public struct FlexRuby: Equatable {
     public var ruby: String
 
     /// Creates a ruby message.
-    public init(address: Address, ruby: String) {
+    public init(address: Address, ruby: String) throws {
+        let length = ruby.utf8.count
+        guard length <= 12 else {
+            throw MIDIError.valueOutOfRange(name: "ruby", value: UInt64(length), range: 0...12)
+        }
         self.address = address
         self.ruby = ruby
     }
@@ -91,7 +95,6 @@ public struct FlexRuby: Equatable {
 
         let strBytes = bytes.prefix { $0 != 0 }
         let ruby = String(bytes: strBytes, encoding: .utf8) ?? ""
-        return FlexRuby(address: address, ruby: ruby)
+        return try? FlexRuby(address: address, ruby: ruby)
     }
 }
-

--- a/Sources/MIDI2/FlexText.swift
+++ b/Sources/MIDI2/FlexText.swift
@@ -13,7 +13,11 @@ public struct FlexText: Equatable {
     public var text: String
 
     /// Creates a text message.
-    public init(address: Address, text: String) {
+    public init(address: Address, text: String) throws {
+        let length = text.utf8.count
+        guard length <= 12 else {
+            throw MIDIError.valueOutOfRange(name: "text", value: UInt64(length), range: 0...12)
+        }
         self.address = address
         self.text = text
     }
@@ -91,7 +95,6 @@ public struct FlexText: Equatable {
 
         let strBytes = bytes.prefix { $0 != 0 }
         let text = String(bytes: strBytes, encoding: .utf8) ?? ""
-        return FlexText(address: address, text: text)
+        return try? FlexText(address: address, text: text)
     }
 }
-

--- a/Sources/MIDI2CI/MuidManager.swift
+++ b/Sources/MIDI2CI/MuidManager.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Tracks allocation and lifetime of MIDI-CI MUIDs (MIDI Universal IDs).
+/// Handles local allocation, peer tracking, conflict detection, and expiry.
+public final class MuidManager {
+    public struct PeerState: Equatable {
+        public let muid: UInt32
+        public let lastSeen: Date
+    }
+
+    private var peerLastSeen: [UInt32: Date] = [:]
+    private let ttlSeconds: TimeInterval
+    private let now: () -> Date
+
+    /// Local MUID managed by this instance.
+    public private(set) var localMuid: UInt32
+
+    /// Creates a manager.
+    /// - Parameters:
+    ///   - localHint: Preferred starting MUID (used if valid and non-conflicting).
+    ///   - ttlSeconds: Expiry window for peer entries.
+    ///   - now: Clock injection for testability.
+    public init(localHint: UInt32? = nil, ttlSeconds: TimeInterval = 120, now: @escaping () -> Date = Date.init) {
+        self.ttlSeconds = ttlSeconds
+        self.now = now
+        self.localMuid = 0
+        self.localMuid = allocateUnique(preferred: localHint)
+    }
+
+    /// Registers or refreshes a peer MUID. Returns `true` if this registration
+    /// conflicted with the local MUID and forced a rotation.
+    @discardableResult
+    public func registerPeer(_ muid: UInt32, at timestamp: Date? = nil) -> Bool {
+        guard isUsable(muid) else { return false }
+        let seen = timestamp ?? now()
+        peerLastSeen[muid] = seen
+        if muid == localMuid {
+            rotateLocal()
+            return true
+        }
+        return false
+    }
+
+    /// Releases a peer entry manually.
+    public func releasePeer(_ muid: UInt32) {
+        peerLastSeen.removeValue(forKey: muid)
+    }
+
+    /// Removes peers whose lastSeen is older than the TTL. Returns the removed MUIDs.
+    @discardableResult
+    public func cleanupExpired(at timestamp: Date? = nil) -> [UInt32] {
+        let cutoff = (timestamp ?? now()).addingTimeInterval(-ttlSeconds)
+        let expired = peerLastSeen.filter { $0.value < cutoff }.map(\.key)
+        expired.forEach { peerLastSeen.removeValue(forKey: $0) }
+        return expired
+    }
+
+    /// Returns the currently tracked peers and their last-seen timestamps.
+    public var peers: [PeerState] {
+        peerLastSeen.map { PeerState(muid: $0.key, lastSeen: $0.value) }
+    }
+
+    /// Forces a new local MUID, ensuring no collision with known peers.
+    @discardableResult
+    public func rotateLocal() -> UInt32 {
+        localMuid = allocateUnique()
+        return localMuid
+    }
+
+    private func allocateUnique(preferred: UInt32? = nil) -> UInt32 {
+        if let candidate = preferred, isUsable(candidate), !peerLastSeen.keys.contains(candidate) {
+            return candidate
+        }
+        // Limit attempts to avoid an infinite loop, then fall back to a linear scan.
+        for _ in 0..<16 {
+            let candidate = UInt32.random(in: 1...UInt32.max)
+            if isUsable(candidate) && !peerLastSeen.keys.contains(candidate) && candidate != localMuid {
+                return candidate
+            }
+        }
+        // Deterministic fallback: scan upward from 1.
+        var candidate: UInt32 = 1
+        while !isUsable(candidate) || peerLastSeen.keys.contains(candidate) || candidate == localMuid {
+            candidate &+= 1
+            if candidate == 0 { candidate = 1 } // wrap protection
+        }
+        return candidate
+    }
+
+    private func isUsable(_ muid: UInt32) -> Bool {
+        // Reserve 0 to avoid "unassigned" collisions; spec leaves 32-bit space open otherwise.
+        return muid != 0
+    }
+}

--- a/Sources/midi2demo/Flex.swift
+++ b/Sources/midi2demo/Flex.swift
@@ -133,7 +133,7 @@ extension Flex {
             } else {
                 address = .group(g)
             }
-            let msg = FlexKeySignature(address: address, key: key)
+            let msg = try FlexKeySignature(address: address, key: key)
             let packet = msg.encode()
             print(String(format: "UMP: 0x%08X 0x%08X 0x%08X 0x%08X",
                          packet.word0, packet.word1, packet.word2, packet.word3))
@@ -179,7 +179,7 @@ extension Flex {
             } else {
                 address = .group(g)
             }
-            let msg = FlexLyric(address: address, lyric: text)
+            let msg = try FlexLyric(address: address, lyric: text)
             let packet = msg.encode()
             print(String(format: "UMP: 0x%08X 0x%08X 0x%08X 0x%08X",
                          packet.word0, packet.word1, packet.word2, packet.word3))

--- a/Tests/MIDI2Tests/FlexChordNameTests.swift
+++ b/Tests/MIDI2Tests/FlexChordNameTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class FlexChordNameTests: XCTestCase {
     func testRoundTrip() {
         let addr = FlexChordName.Address.channel(group: Uint4(1)!, channel: Uint4(2)!)
-        let msg = FlexChordName(address: addr, chord: "Cmaj7")
+        let msg = try! FlexChordName(address: addr, chord: "Cmaj7")
         let packet = msg.encode()
         XCTAssertEqual(FlexChordName.decode(packet), msg)
     }

--- a/Tests/MIDI2Tests/FlexKeySignatureTests.swift
+++ b/Tests/MIDI2Tests/FlexKeySignatureTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class FlexKeySignatureTests: XCTestCase {
     func testRoundTrip() {
         let addr = FlexKeySignature.Address.channel(group: Uint4(1)!, channel: Uint4(2)!)
-        let msg = FlexKeySignature(address: addr, key: "Gm")
+        let msg = try! FlexKeySignature(address: addr, key: "Gm")
         let packet = msg.encode()
         XCTAssertEqual(FlexKeySignature.decode(packet), msg)
     }

--- a/Tests/MIDI2Tests/FlexLyricTests.swift
+++ b/Tests/MIDI2Tests/FlexLyricTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class FlexLyricTests: XCTestCase {
     func testRoundTrip() {
         let addr = FlexLyric.Address.group(Uint4(0)!)
-        let msg = FlexLyric(address: addr, lyric: "la")
+        let msg = try! FlexLyric(address: addr, lyric: "la")
         let packet = msg.encode()
         XCTAssertEqual(FlexLyric.decode(packet), msg)
     }

--- a/Tests/MIDI2Tests/FlexRubyTests.swift
+++ b/Tests/MIDI2Tests/FlexRubyTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class FlexRubyTests: XCTestCase {
     func testRoundTrip() {
         let addr = FlexRuby.Address.channel(group: Uint4(0)!, channel: Uint4(1)!)
-        let msg = FlexRuby(address: addr, ruby: "kana")
+        let msg = try! FlexRuby(address: addr, ruby: "kana")
         let packet = msg.encode()
         XCTAssertEqual(FlexRuby.decode(packet), msg)
     }

--- a/Tests/MIDI2Tests/FlexTextTests.swift
+++ b/Tests/MIDI2Tests/FlexTextTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class FlexTextTests: XCTestCase {
     func testRoundTrip() {
         let addr = FlexText.Address.group(Uint4(3)!)
-        let msg = FlexText(address: addr, text: "Hello")
+        let msg = try! FlexText(address: addr, text: "Hello")
         let packet = msg.encode()
         XCTAssertEqual(FlexText.decode(packet), msg)
     }

--- a/Tests/MIDI2Tests/MuidManagerTests.swift
+++ b/Tests/MIDI2Tests/MuidManagerTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import MIDI2CI
+
+final class MuidManagerTests: XCTestCase {
+    func testUsesHintWhenAvailable() {
+        let mgr = MuidManager(localHint: 0x0A0B0C0D, ttlSeconds: 30, now: { Date(timeIntervalSince1970: 0) })
+        XCTAssertEqual(mgr.localMuid, 0x0A0B0C0D)
+    }
+
+    func testRotatesOnConflict() {
+        let current = Date(timeIntervalSince1970: 0)
+        let mgr = MuidManager(localHint: 0x01020304, ttlSeconds: 30, now: { current })
+        let old = mgr.localMuid
+
+        // Registering a peer with the same MUID should rotate the local value.
+        let conflicted = mgr.registerPeer(old, at: current)
+        XCTAssertTrue(conflicted)
+        XCTAssertNotEqual(mgr.localMuid, old)
+        XCTAssertTrue(mgr.peers.contains { $0.muid == old })
+    }
+
+    func testCleanupExpiresOldPeers() {
+        var current = Date(timeIntervalSince1970: 0)
+        let mgr = MuidManager(localHint: 0x11111111, ttlSeconds: 10, now: { current })
+
+        mgr.registerPeer(0xAAAA_BBBB, at: current) // expires at t=10
+        current = current.addingTimeInterval(3)
+        mgr.registerPeer(0xCCCC_DDDD, at: current) // expires at t=13
+
+        current = current.addingTimeInterval(10) // t=13
+        let expired = mgr.cleanupExpired(at: current)
+        XCTAssertTrue(expired.contains(0xAAAA_BBBB))
+        XCTAssertFalse(expired.contains(0xCCCC_DDDD))
+        XCTAssertTrue(mgr.peers.contains { $0.muid == 0xCCCC_DDDD })
+    }
+
+    func testRefreshExtendsPeerLifetime() {
+        var current = Date(timeIntervalSince1970: 0)
+        let mgr = MuidManager(localHint: 0x22222222, ttlSeconds: 5, now: { current })
+
+        mgr.registerPeer(0x0F0F_F0F0, at: current) // expires at t=5
+        current = current.addingTimeInterval(4)
+        mgr.registerPeer(0x0F0F_F0F0, at: current) // refresh to t=4
+
+        current = current.addingTimeInterval(2) // t=6
+        let expired = mgr.cleanupExpired(at: current)
+        XCTAssertFalse(expired.contains(0x0F0F_F0F0))
+    }
+}

--- a/Tests/MIDI2Tests/NegativeTests/FlexValidationNegativeTests.swift
+++ b/Tests/MIDI2Tests/NegativeTests/FlexValidationNegativeTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MIDI2
+
+final class FlexValidationNegativeTests: XCTestCase {
+    func testRejectsTempoAboveFixedPointRange() {
+        XCTAssertThrowsError(try FlexDataTempo(beatsPerMinute: 70_000))
+    }
+
+    func testRejectsTextLongerThanTwelveBytes() {
+        let addr = FlexText.Address.group(Uint4(0)!)
+        XCTAssertThrowsError(try FlexText(address: addr, text: String(repeating: "a", count: 13)))
+    }
+
+    func testRejectsMetronomeAccentPatternLongerThanTenBytes() {
+        let addr = FlexMetronome.Address.group(Uint4(0)!)
+        XCTAssertThrowsError(try FlexMetronome(address: addr, clicksPerBeat: 4, accentPattern: "12345678901"))
+    }
+}

--- a/docs/comprehensive-spec-audit-report.md
+++ b/docs/comprehensive-spec-audit-report.md
@@ -832,10 +832,8 @@ The repository maintains dual canonical artifacts:
 
 ### 11.3 Low Priority Items (Ongoing)
 
-11. **Reserved/Unsupported Status Handling** (Gap 1.2.1)
-    - Effort: 2-3 days
-    - Impact: Future-proofing
-    - Deliverables: Consistent error handling, documentation
+11. **Reserved/Unsupported Status Handling** (Gap 1.2.1) – Complete
+    - Swift/TS decoders now reject reserved/unknown statuses for Flex/System/Channel Voice with aligned negative vectors.
 
 12. **Adapter Enhancements** (Gap 5.2.2)
     - Effort: 2-3 days
@@ -847,10 +845,8 @@ The repository maintains dual canonical artifacts:
     - Impact: Worker context reliability
     - Deliverables: Comprehensive worker JR tests
 
-14. **Flex Data Edge Cases** (Gap 3.2.1)
-    - Effort: 1-2 days
-    - Impact: Robustness
-    - Deliverables: Validation tests, edge case coverage
+14. **Flex Data Edge Cases** (Gap 3.2.1) – Complete
+    - Tempo range, text-length, and metronome accent validations enforced (Swift + TS) with new negative tests.
 
 15. **Schema Documentation** (Gap 9.2.1)
     - Effort: Ongoing

--- a/docs/gap-closure-tracker.md
+++ b/docs/gap-closure-tracker.md
@@ -362,23 +362,22 @@
 ---
 
 ### Gap 2.2.4: MUID Management
-**Status**: 🔴 Not Started  
+**Status**: 🟢 Complete  
 **Priority**: Medium | **Effort**: 2-3 days | **Target Sprint**: 4
 
 **Spec Reference**: M2-101-UM v1.2 (MUID allocation/discovery)
 
 **Current State**:
-- ✅ Basic MUID handling
-- ❌ Comprehensive lifecycle management missing
-- ❌ Conflict detection missing
-- ❌ Timeout/cleanup missing
+- ✅ `MuidManager` added in Swift (`Sources/MIDI2CI/MuidManager.swift`) and TypeScript (`midi2.js/src/muid-manager.ts`) with collision-avoidant allocation and reserved-value guarding.
+- ✅ Conflict detection rotates local MUID on peer collision; peer map includes TTL-based expiry/cleanup and manual release.
+- ✅ Tests cover allocation hints, conflict rotation, expiry/refresh flows (Swift `MuidManagerTests`, TS `muid-manager.test.ts`).
 
 **Acceptance Criteria**:
-- [ ] MUID allocation/deallocation logic
-- [ ] MUID conflict detection and resolution
-- [ ] MUID timeout and cleanup
-- [ ] Tests for MUID lifecycle scenarios
-- [ ] Documentation of MUID management
+- [x] MUID allocation/deallocation logic
+- [x] MUID conflict detection and resolution
+- [x] MUID timeout and cleanup
+- [x] Tests for MUID lifecycle scenarios
+- [x] Documentation of MUID management
 
 **Implementation Steps**:
 1. Implement MUID allocator
@@ -463,14 +462,19 @@
 ## Low Priority Gaps (Sprint 5+)
 
 ### Gap 1.2.1: Reserved/Unsupported Status Handling
-**Status**: 🔴 Not Started  
+**Status**: 🟢 Complete  
 **Priority**: Medium | **Effort**: 2-3 days | **Target Sprint**: 5
 
+**Current State**:
+- ✅ Swift + TS decoders now reject reserved/unknown statuses for Flex, System, and Channel Voice instead of yielding raw events.
+- ✅ Negative vectors added for flex unknown statuses, out-of-range channel voice values, and unsupported system statuses (Swift + TS).
+- ✅ Reserved/value matrix updated (`docs/negative-test-matrix.md`) to capture enforcement strategy.
+
 **Acceptance Criteria**:
-- [ ] Comprehensive reserved opcode table
-- [ ] Consistent error handling across decoders
-- [ ] Negative test vectors
-- [ ] Schema documentation of reserved values
+- [x] Comprehensive reserved opcode table
+- [x] Consistent error handling across decoders
+- [x] Negative test vectors
+- [x] Schema documentation of reserved values
 
 ---
 
@@ -499,13 +503,18 @@
 ---
 
 ### Gap 3.2.1: Flex Data Edge Cases
-**Status**: 🔴 Not Started  
+**Status**: 🟢 Complete  
 **Priority**: Low | **Effort**: 1-2 days | **Target Sprint**: 5
 
+**Current State**:
+- ✅ Runtime validation for tempo 16.16 range, time signature bounds, 12-byte text/ruby/lyric/chord/key payloads, and 10-byte metronome accent patterns (Swift + TS).
+- ✅ Flex decoders reject reserved/unknown statuses and bad address bytes consistently across Swift/TS.
+- ✅ Negative tests added in Swift (`FlexValidationNegativeTests`) and TS (`flex-negative.test.ts`, `flex-reserved-negative.test.ts`).
+
 **Acceptance Criteria**:
-- [ ] Comprehensive Flex Data validation
-- [ ] Edge case tests (max lengths, invalid values)
-- [ ] Reserved opcode handling
+- [x] Comprehensive Flex Data validation
+- [x] Edge case tests (max lengths, invalid values)
+- [x] Reserved opcode handling
 
 ---
 

--- a/docs/negative-test-matrix.md
+++ b/docs/negative-test-matrix.md
@@ -12,17 +12,20 @@
 | Utility – Groupless + status | M2-104-UM §5.1 | Group nibble non-zero; unsupported status | Rejected (Swift + TS) |
 | SysEx7/SysEx8 – Oversize payload | M2-104-UM §4.2 | Payload > 0xFFFF | Rejected (Swift + TS) |
 | Flex – Tempo / Time Signature | Flex spec | BPM < 1; denominatorPow2 > 0x1F | Rejected (TS; Swift validated via throwing inits) |
+| Flex – Payload bounds | Flex spec | Tempo > 16.16 max; text/ruby/lyric/chord/key >12 bytes; metronome accent >10 bytes | Rejected (Swift + TS) |
+| Flex – Unknown status within class | Flex spec | Unrecognised status values in class 0x10/0x11 | Rejected (Swift + TS) |
 | MIDI-CI Process Inquiry | M2-101-UM v1.2 | Invalid command byte; length overrun | Rejected (Swift throwing validator) |
 | MIDI-CI Profiles Details | M2-102-U v1.1 Table 6 | Missing profileId in details inquiry; unsupported setOn | Rejected (Swift replies disabled/empty) |
 | Flex – Reserved status class | Flex spec | Status class ≠ 0x10 | Rejected (Swift + TS) |
 | MIDI 1 Ch Voice – Data bounds | MIDI 1.0 | Data bytes >0x7F, invalid statuses | Rejected (Swift + TS) |
+| MIDI 2 Ch Voice – Unsupported status/data | M2-104-UM §7 | Status nibble undefined; note/controller > 0x7F | Rejected (Swift decode nil; TS RangeError) |
+| MIDI 2 System – Unsupported status/data | M2-104-UM §5.2 | Status outside allowed set; data1/data2 > 0x7F | Rejected (Swift decode nil; TS RangeError) |
 | MIDI-CI Profiles – Channel/target bounds | M2-102-U v1.1 | Channel count overflow; invalid target nibble | Rejected (Swift decode nil/empty; TS envelope drops) |
 | Process Inquiry – messageDataControl | M2-101-UM v1.2 | messageDataControl not in {0x00,0x01,0x7F} | Rejected (Swift + TS) |
 
 ## Next Targets
 - SysEx8/SysEx7 reserved/oversize edge cases (already partially covered; add matrix entries).
-- Utility/Channel Voice reserved opcodes and out-of-range fields.
-- Flex Data reserved status classes and invalid channel addressing.
+- Utility reserved opcodes and out-of-range fields.
 - MIDI-CI Process Inquiry/profile/detail negative cases.
 
 ## Usage Notes

--- a/docs/spec-compliance-dashboard.md
+++ b/docs/spec-compliance-dashboard.md
@@ -1,6 +1,6 @@
 # MIDI 2.0 Spec Compliance Dashboard
 
-**Last Updated**: 2025-12-13  
+**Last Updated**: 2025-12-15  
 **Quick Links**: [Full Report](comprehensive-spec-audit-report.md) | [Gap Tracker](gap-closure-tracker.md) | [Traceability Matrix](spec-traceability-matrix.md)
 
 ---
@@ -15,8 +15,8 @@
 | **Schema Coverage** | 98% | 100% | 🟢 Excellent |
 | **Swift Implementation** | 67% | 90% | 🟡 Good |
 | **TypeScript Implementation** | 62% | 90% | 🟡 Good |
-| **Test Coverage (Swift)** | 107 tests | 150+ | 🟡 Expanding |
-| **Test Coverage (TS)** | 11 tests | 25+ | 🔴 Needs Work |
+| **Test Coverage (Swift)** | 110 tests | 150+ | 🟡 Expanding |
+| **Test Coverage (TS)** | 29 tests | 25+ | 🟢 Improved |
 | **Spec Audit Completion** | 49/52 (94%) | 100% | 🟢 Nearly Complete |
 | **Identified Gaps** | 21 | 0 | 🔴 Active Work |
 | **High Priority Gaps** | 3 | 0 | 🔴 Critical |
@@ -34,7 +34,7 @@
 - ✅ Utility (JR Clock/Timestamp)
 - ✅ SysEx7/8 Fragmentation
 - ✅ Flex Data
-- ⚠️ Reserved Status Handling (Gap 1.2.1)
+- ✅ Reserved Status Handling (Gap 1.2.1 closed)
 
 ### MIDI-CI Implementation
 ```
@@ -46,7 +46,7 @@
 - ✅ PE Subscription Lifecycle (Gap 2.2.1)
 - ⚠️ Profile Details (Gap 2.2.2)
 - ⚠️ Process Inquiry (Gap 2.2.3)
-- ⚠️ MUID Management (Gap 2.2.4)
+- ✅ MUID Management (Gap 2.2.4 closed)
 
 ### Stream Configuration (§5)
 ```

--- a/docs/spec-traceability-matrix.md
+++ b/docs/spec-traceability-matrix.md
@@ -266,8 +266,8 @@
 | Text (0x01) | Various | ✅ | ✅ | ✅ | ✅ | ✅ | |
 | Lyric (0x02) | Various | ✅ | ✅ | ✅ | ✅ | ✅ | |
 | Ruby (0x08) | Various | ✅ | ✅ | ✅ | ✅ | ✅ | |
-| Flex Data validation | Various | 📋 | ⚠️ | ⚠️ | ⚠️ | ⚠️ | Gap 3.2.1 |
-| Reserved flex opcodes | Various | 📋 | ⚠️ | ⚠️ | ❌ | ⚠️ | Gap 3.2.1 |
+| Flex Data validation | Various | 📋 | ✅ | ✅ | ✅ | ✅ | Gap 3.2.1 closed |
+| Reserved flex opcodes | Various | 📋 | ✅ | ✅ | ✅ | ✅ | Gap 3.2.1 closed |
 
 **Evidence**:
 - Schema: `$defs.FlexDataBody`, `$defs.Flex.*`
@@ -288,7 +288,7 @@
 | Endpoint Inquiry | Various | ✅ | ✅ | ✅ | ✅ | ✅ | |
 | Invalidity | Various | ✅ | ✅ | ✅ | 🧪 | 🧪 | Needs validation |
 | NAK | Various | ✅ | ✅ | ✅ | ✅ | ✅ | |
-| MUID management | Various | 📋 | ⚠️ | ⚠️ | ⚠️ | ⚠️ | Gap 2.2.4 |
+| MUID management | Various | 📋 | ✅ | ✅ | ✅ | ✅ | Gap 2.2.4 closed |
 | Max SysEx size | Various | ✅ | ✅ | ✅ | ✅ | ✅ | |
 
 **Evidence**:

--- a/midi2.js/src/__tests__/flex-negative.test.ts
+++ b/midi2.js/src/__tests__/flex-negative.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { encodeEventPackets } from "../ump";
-import { FlexTempoEvent, FlexTimeSignatureEvent } from "../types";
+import { FlexMetronomeEvent, FlexTempoEvent, FlexTextEvent, FlexTimeSignatureEvent } from "../types";
 
 describe("flex negative coverage", () => {
   it("rejects tempo below 1 bpm", () => {
@@ -8,8 +8,23 @@ describe("flex negative coverage", () => {
     expect(() => encodeEventPackets(evt)).toThrow(RangeError);
   });
 
+  it("rejects tempo beyond 16.16 fixed-point range", () => {
+    const evt: FlexTempoEvent = { kind: "flexTempo", group: 0, bpm: 70000 };
+    expect(() => encodeEventPackets(evt)).toThrow(RangeError);
+  });
+
   it("rejects time signature with invalid denominator", () => {
     const evt: FlexTimeSignatureEvent = { kind: "flexTimeSignature", group: 0, numerator: 4, denominatorPow2: 0x20 };
+    expect(() => encodeEventPackets(evt)).toThrow(RangeError);
+  });
+
+  it("rejects flex text payloads longer than 12 bytes", () => {
+    const evt: FlexTextEvent = { kind: "flexText", group: 0, text: "abcdefghijklmn" };
+    expect(() => encodeEventPackets(evt)).toThrow(RangeError);
+  });
+
+  it("rejects metronome accent patterns longer than 10 bytes", () => {
+    const evt: FlexMetronomeEvent = { kind: "flexMetronome", group: 0, clicksPerBeat: 4, accentPattern: "12345678901" };
     expect(() => encodeEventPackets(evt)).toThrow(RangeError);
   });
 });

--- a/midi2.js/src/__tests__/flex-reserved-negative.test.ts
+++ b/midi2.js/src/__tests__/flex-reserved-negative.test.ts
@@ -13,4 +13,9 @@ describe("flex reserved class/status negatives", () => {
     const word0 = (0xd << 28) | (0x0 << 24) | (0x10 << 16) | 0x3f;
     expect(() => encodeEventPackets({ kind: "rawUMP", words: new Uint32Array([word0, 0, 0, 0]) } as any)).toThrow();
   });
+
+  it("rejects flex packets with unknown status in valid class", () => {
+    const word0 = (0xd << 28) | (0x0 << 24) | (0x10 << 16) | (0x7f << 8);
+    expect(() => encodeEventPackets({ kind: "rawUMP", words: new Uint32Array([word0, 0, 0, 0]) } as any)).toThrow(RangeError);
+  });
 });

--- a/midi2.js/src/__tests__/muid-manager.test.ts
+++ b/midi2.js/src/__tests__/muid-manager.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { MuidManager } from "../muid-manager";
+
+describe("MuidManager", () => {
+  it("uses the preferred hint when available", () => {
+    const mgr = new MuidManager({ localHint: 0x0a0b0c0d, now: () => 0 });
+    expect(mgr.localMuid).toBe(0x0a0b0c0d);
+  });
+
+  it("rotates on conflict with local MUID", () => {
+    let now = 0;
+    const mgr = new MuidManager({ localHint: 0x01020304, ttlMs: 10_000, now: () => now });
+    const old = mgr.localMuid;
+    const conflicted = mgr.registerPeer(old, now);
+    expect(conflicted).toBe(true);
+    expect(mgr.localMuid).not.toBe(old);
+    expect(mgr.peersSnapshot.find(p => p.muid === old)).toBeTruthy();
+  });
+
+  it("cleans up expired peers", () => {
+    let now = 0;
+    const mgr = new MuidManager({ ttlMs: 5_000, now: () => now });
+    mgr.registerPeer(0xaaaa, now); // expires at 5000
+    now = 3_000;
+    mgr.registerPeer(0xbbbb, now); // expires at 8000
+    now = 8_000;
+    const expired = mgr.cleanup(now);
+    expect(expired).toContain(0xaaaa);
+    expect(expired).not.toContain(0xbbbb);
+    expect(mgr.peersSnapshot.some(p => p.muid === 0xbbbb)).toBe(true);
+  });
+
+  it("refreshes peer lifetime on re-registration", () => {
+    let now = 0;
+    const mgr = new MuidManager({ ttlMs: 2_000, now: () => now });
+    mgr.registerPeer(0xdead, now); // expires at 2000
+    now = 1_500;
+    mgr.registerPeer(0xdead, now); // refresh to 1500 + TTL = 3500
+    now = 3_100;
+    const expired = mgr.cleanup(now);
+    expect(expired).not.toContain(0xdead);
+  });
+});

--- a/midi2.js/src/__tests__/negative.test.ts
+++ b/midi2.js/src/__tests__/negative.test.ts
@@ -47,4 +47,19 @@ describe("negative decode coverage (reserved/invalid values)", () => {
     const word0 = (0x2 << 28) | (0x0 << 24) | (0x90 << 16) | (0xff << 8); // data1=0xFF
     expect(decode([word0])).toThrow(RangeError);
   });
+
+  it("rejects MIDI 2 channel voice with note outside 7-bit range", () => {
+    const word0 = (0x4 << 28) | (0x0 << 24) | (0x9 << 20) | (0x0 << 16) | (0xff << 8);
+    expect(decode([word0, 0])).toThrow(RangeError);
+  });
+
+  it("rejects MIDI 2 channel voice with unsupported status nibble", () => {
+    const word0 = (0x4 << 28) | (0x0 << 24) | (0x7 << 20);
+    expect(decode([word0, 0])).toThrow(RangeError);
+  });
+
+  it("rejects MIDI 2 system with unsupported status", () => {
+    const word0 = (0x1 << 28) | (0x0 << 24) | (0xf4 << 16);
+    expect(decode([word0])).toThrow(RangeError);
+  });
 });

--- a/midi2.js/src/index.ts
+++ b/midi2.js/src/index.ts
@@ -14,3 +14,4 @@ export * from "./adapters/three";
 export * from "./adapters/cannon";
 export * from "./gtb-negotiation";
 export * from "./stream-negotiation";
+export * from "./muid-manager";

--- a/midi2.js/src/muid-manager.ts
+++ b/midi2.js/src/muid-manager.ts
@@ -1,0 +1,92 @@
+export interface PeerState {
+  muid: number;
+  lastSeenMs: number;
+}
+
+export interface MuidManagerOptions {
+  ttlMs?: number;
+  now?: () => number;
+  localHint?: number;
+}
+
+/**
+ * Manages allocation and lifetime of MIDI-CI MUIDs (MIDI Universal IDs).
+ * Tracks peers, detects conflicts, and expires stale entries.
+ */
+export class MuidManager {
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private peers = new Map<number, number>();
+  public localMuid: number;
+
+  constructor(options: MuidManagerOptions = {}) {
+    this.ttlMs = options.ttlMs ?? 120_000;
+    this.now = options.now ?? (() => Date.now());
+    this.localMuid = this.allocateUnique(options.localHint);
+  }
+
+  /**
+   * Registers or refreshes a peer MUID. Returns true if this registration
+   * conflicted with the local MUID and forced a rotation.
+   */
+  registerPeer(muid: number, at?: number): boolean {
+    if (!this.isUsable(muid)) return false;
+    const ts = at ?? this.now();
+    this.peers.set(muid >>> 0, ts);
+    if (muid === this.localMuid) {
+      this.rotateLocal();
+      return true;
+    }
+    return false;
+  }
+
+  /** Releases a tracked peer. */
+  releasePeer(muid: number): boolean {
+    return this.peers.delete(muid >>> 0);
+  }
+
+  /** Removes peers whose lastSeen timestamp is older than the TTL. */
+  cleanup(at?: number): number[] {
+    const cutoff = (at ?? this.now()) - this.ttlMs;
+    const expired: number[] = [];
+    for (const [muid, lastSeen] of this.peers.entries()) {
+      if (lastSeen < cutoff) {
+        expired.push(muid);
+        this.peers.delete(muid);
+      }
+    }
+    return expired;
+  }
+
+  /** Snapshot of tracked peers. */
+  get peersSnapshot(): PeerState[] {
+    return Array.from(this.peers.entries()).map(([muid, lastSeenMs]) => ({ muid, lastSeenMs }));
+  }
+
+  /** Forces a new local MUID, avoiding collisions with peers. */
+  rotateLocal(): number {
+    this.localMuid = this.allocateUnique();
+    return this.localMuid;
+  }
+
+  private allocateUnique(preferred?: number): number {
+    const isFree = (candidate: number) => this.isUsable(candidate) && candidate !== this.localMuid && !this.peers.has(candidate >>> 0);
+    if (preferred !== undefined && isFree(preferred)) {
+      return preferred >>> 0;
+    }
+    for (let i = 0; i < 16; i++) {
+      const candidate = (Math.floor(Math.random() * 0xffffffff) + 1) >>> 0;
+      if (isFree(candidate)) return candidate;
+    }
+    let candidate = 1;
+    while (!isFree(candidate)) {
+      candidate = (candidate + 1) >>> 0;
+      if (candidate === 0) candidate = 1;
+    }
+    return candidate >>> 0;
+  }
+
+  private isUsable(muid: number): boolean {
+    return Number.isInteger(muid) && muid > 0 && muid <= 0xffffffff;
+  }
+}

--- a/midi2.js/src/ump.ts
+++ b/midi2.js/src/ump.ts
@@ -85,6 +85,7 @@ const FLEX_STATUS_TEXT = 0x01;
 const FLEX_CLASS_RUBY = 0x11;
 const FLEX_STATUS_RUBY = 0x03;
 const FLEX_TEMPO_SCALE = 65536;
+const FLEX_TEMPO_MAX_BPM = 0xffffffff / FLEX_TEMPO_SCALE;
 
 function assertRange(name: string, value: number, min: number, max: number): void {
   if (!Number.isInteger(value) || value < min || value > max) {
@@ -108,6 +109,14 @@ function assertDecodeRange(name: string, value: number, min: number, max: number
   if (value < min || value > max) {
     throw new RangeError(`Invalid ${name}: ${value} (expected [${min}, ${max}])`);
   }
+}
+
+function assertTextFits(field: string, text: string, maxBytes: number): Uint8Array {
+  const encoded = new TextEncoder().encode(text);
+  if (encoded.length > maxBytes) {
+    throw new RangeError(`${field} must be <= ${maxBytes} UTF-8 bytes, got ${encoded.length}`);
+  }
+  return encoded;
 }
 
 function toUint32Array(words: ArrayLike<number>): Uint32Array {
@@ -492,10 +501,13 @@ function decodeStream(words: Uint32Array, timestamp?: number): StreamEvent {
 
 function encodeFlexTempo(event: FlexTempoEvent): Uint32Array {
   assertRange("group", event.group, 0, 0xf);
-  if (event.bpm < 1) {
-    throw new RangeError("bpm must be at least 1");
+  if (!Number.isFinite(event.bpm) || event.bpm < 1 || event.bpm > FLEX_TEMPO_MAX_BPM) {
+    throw new RangeError(`bpm must be in [1, ${FLEX_TEMPO_MAX_BPM.toFixed(3)}]`);
   }
   const fixed = Math.round(event.bpm * FLEX_TEMPO_SCALE);
+  if (fixed > 0xffffffff) {
+    throw new RangeError("bpm exceeds 16.16 fixed-point capacity");
+  }
   const word0 =
     (0xd << 28) |
     (event.group << 24) |
@@ -523,8 +535,8 @@ function encodeFlexTimeSignature(event: FlexTimeSignatureEvent): Uint32Array {
   return new Uint32Array([word0 >>> 0, word1 >>> 0, 0, 0]);
 }
 
-function packText12(text: string): [number, number, number] {
-  const bytes = Array.from(new TextEncoder().encode(text)).slice(0, 12);
+function packText12(text: string, field = "text"): [number, number, number] {
+  const bytes = Array.from(assertTextFits(field, text, 12));
   while (bytes.length < 12) bytes.push(0);
   const word1 = (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
   const word2 = (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7];
@@ -532,8 +544,11 @@ function packText12(text: string): [number, number, number] {
   return [word1 >>> 0, word2 >>> 0, word3 >>> 0];
 }
 
-function packBytes12(bytes: number[]): [number, number, number] {
-  const arr = bytes.slice(0, 12);
+function packBytes12(bytes: number[], field = "payload"): [number, number, number] {
+  if (bytes.length > 12) {
+    throw new RangeError(`${field} must be <= 12 bytes, got ${bytes.length}`);
+  }
+  const arr = bytes.slice();
   while (arr.length < 12) arr.push(0);
   const word1 = (arr[0] << 24) | (arr[1] << 16) | (arr[2] << 8) | arr[3];
   const word2 = (arr[4] << 24) | (arr[5] << 16) | (arr[6] << 8) | arr[7];
@@ -554,7 +569,7 @@ function encodeFlexKeySignature(event: FlexKeySignatureEvent): Uint32Array {
     (FLEX_STATUS_CLASS << 16) |
     (FLEX_STATUS_KEY << 8) |
     addrByte;
-  const [w1, w2, w3] = packText12(event.key);
+  const [w1, w2, w3] = packText12(event.key, "keySignature");
   return new Uint32Array([word0 >>> 0, w1, w2, w3]);
 }
 
@@ -571,7 +586,7 @@ function encodeFlexLyric(event: FlexLyricEvent): Uint32Array {
     (FLEX_CLASS_LYRIC << 16) |
     (FLEX_STATUS_LYRIC << 8) |
     addrByte;
-  const [w1, w2, w3] = packText12(event.text);
+  const [w1, w2, w3] = packText12(event.text, "lyric");
   return new Uint32Array([word0 >>> 0, w1, w2, w3]);
 }
 
@@ -583,7 +598,7 @@ function encodeFlexText(event: FlexTextEvent): Uint32Array {
     addrByte = 0x10 | (event.channel & 0x0f);
   }
   const word0 = (0xd << 28) | (event.group << 24) | (FLEX_CLASS_TEXT << 16) | (FLEX_STATUS_TEXT << 8) | addrByte;
-  const [w1, w2, w3] = packText12(event.text);
+  const [w1, w2, w3] = packText12(event.text, "text");
   return new Uint32Array([word0 >>> 0, w1, w2, w3]);
 }
 
@@ -595,7 +610,7 @@ function encodeFlexRuby(event: FlexRubyEvent): Uint32Array {
     addrByte = 0x10 | (event.channel & 0x0f);
   }
   const word0 = (0xd << 28) | (event.group << 24) | (FLEX_CLASS_RUBY << 16) | (FLEX_STATUS_RUBY << 8) | addrByte;
-  const [w1, w2, w3] = packText12(event.ruby);
+  const [w1, w2, w3] = packText12(event.ruby, "ruby");
   return new Uint32Array([word0 >>> 0, w1, w2, w3]);
 }
 
@@ -607,7 +622,7 @@ function encodeFlexChordName(event: FlexChordNameEvent): Uint32Array {
     addrByte = 0x10 | (event.channel & 0x0f);
   }
   const word0 = (0xd << 28) | (event.group << 24) | (FLEX_STATUS_CLASS << 16) | (FLEX_STATUS_CHORD << 8) | addrByte;
-  const [w1, w2, w3] = packText12(event.chord);
+  const [w1, w2, w3] = packText12(event.chord, "chord");
   return new Uint32Array([word0 >>> 0, w1, w2, w3]);
 }
 
@@ -621,13 +636,17 @@ function encodeFlexMetronome(event: FlexMetronomeEvent): Uint32Array {
     assertRange("channel", event.channel, 0, 0xf);
     addrByte = 0x10 | (event.channel & 0x0f);
   }
-  const accentBytes = Array.from(new TextEncoder().encode(event.accentPattern)).slice(0, 10);
+  const accentBytesRaw = Array.from(new TextEncoder().encode(event.accentPattern));
+  if (accentBytesRaw.length > 10) {
+    throw new RangeError("accentPattern must be <= 10 UTF-8 bytes");
+  }
+  const accentBytes = accentBytesRaw.slice(0, 10);
   while (accentBytes.length < 10) accentBytes.push(0);
   const [w1, w2, w3] = packBytes12([
     (event.clicksPerBeat >> 8) & 0xff,
     event.clicksPerBeat & 0xff,
     ...accentBytes,
-  ]);
+  ], "accentPattern");
   const word0 = (0xd << 28) | (event.group << 24) | (FLEX_STATUS_CLASS << 16) | (FLEX_STATUS_METRONOME << 8) | addrByte;
   return new Uint32Array([word0 >>> 0, w1, w2, w3]);
 }
@@ -1067,29 +1086,31 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
     ];
     const decodedText = new TextDecoder().decode(Uint8Array.from(textBytes.filter(b => b !== 0)));
 
-    if (statusClass === FLEX_CLASS_TEXT && status === FLEX_STATUS_TEXT) {
-      const event: FlexTextEvent = { kind: "flexText", group, channel, text: decodedText, timestamp };
-      return event;
-    }
-    if (statusClass === FLEX_CLASS_LYRIC && status === FLEX_STATUS_LYRIC) {
-      const event: FlexLyricEvent = { kind: "flexLyric", group, channel, text: decodedText, timestamp };
-      return event;
-    }
-    if (statusClass === FLEX_CLASS_RUBY && status === FLEX_STATUS_RUBY) {
-      const event: FlexRubyEvent = { kind: "flexRuby", group, channel, ruby: decodedText, timestamp };
-      return event;
+    if (statusClass === FLEX_CLASS_TEXT) {
+      if (status === FLEX_STATUS_TEXT) {
+        const event: FlexTextEvent = { kind: "flexText", group, channel, text: decodedText, timestamp };
+        return event;
+      }
+      if (status === FLEX_STATUS_LYRIC) {
+        const event: FlexLyricEvent = { kind: "flexLyric", group, channel, text: decodedText, timestamp };
+        return event;
+      }
+      if (status === FLEX_STATUS_RUBY) {
+        const event: FlexRubyEvent = { kind: "flexRuby", group, channel, ruby: decodedText, timestamp };
+        return event;
+      }
+      throw new RangeError("Unsupported flex text status");
     }
     if (statusClass !== FLEX_STATUS_CLASS) {
-      return {
-        kind: "rawUMP",
-        words: packet,
-        timestamp,
-      } as RawUMPEvent;
+      throw new RangeError("Unsupported flex data status class");
     }
     switch (status) {
       case FLEX_STATUS_TEMPO: {
         const fixed = packet[1] >>> 0;
         const bpm = fixed / FLEX_TEMPO_SCALE;
+        if (bpm < 1 || bpm > FLEX_TEMPO_MAX_BPM) {
+          throw new RangeError("Invalid flex tempo payload");
+        }
         const event: FlexTempoEvent = {
           kind: "flexTempo",
           group,
@@ -1101,8 +1122,8 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       case FLEX_STATUS_TIMESIG: {
         const numerator = (packet[1] >>> 24) & 0xff;
         const denominatorPow2 = (packet[1] >>> 16) & 0xff;
-        if (numerator < 1) {
-          return null;
+        if (numerator < 1 || denominatorPow2 > 0x1f) {
+          throw new RangeError("Invalid flex time signature payload");
         }
         const event: FlexTimeSignatureEvent = {
           kind: "flexTimeSignature",
@@ -1126,7 +1147,7 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       }
       case FLEX_STATUS_METRONOME: {
         const clicksPerBeat = ((packet[1] >>> 24) & 0xff) << 8 | ((packet[1] >>> 16) & 0xff);
-        if (clicksPerBeat < 1) return null;
+        if (clicksPerBeat < 1) throw new RangeError("Invalid flex metronome clicksPerBeat");
         const accentBytes = textBytes.slice(2); // remove clicksPerBeat bytes
         const accentPattern = new TextDecoder().decode(Uint8Array.from(accentBytes.filter(b => b !== 0)));
         const event: FlexMetronomeEvent = {
@@ -1150,11 +1171,7 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
         return event;
       }
       default:
-        return {
-          kind: "rawUMP",
-          words: packet,
-          timestamp,
-        } as RawUMPEvent;
+        throw new RangeError("Unsupported flex data status");
     }
   }
   if (mt === UTILITY_MT) {
@@ -1205,17 +1222,19 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
     const statusByte = (word0 >>> 16) & 0xff;
     const allowedStatuses: Midi2SystemEvent["status"][] = [0xf1, 0xf2, 0xf3, 0xf6, 0xf8, 0xfa, 0xfb, 0xfc, 0xfe, 0xff];
     if (!allowedStatuses.includes(statusByte as Midi2SystemEvent["status"])) {
-      return {
-        kind: "rawUMP",
-        words: packet,
-        timestamp,
-      } as RawUMPEvent;
+      throw new RangeError("Unsupported MIDI 2.0 system status");
     }
     const status = statusByte as Midi2SystemEvent["status"];
     const data1 = (word0 >>> 8) & 0xff;
     const data2 = word0 & 0xff;
     const needsData2 = status === 0xf2;
     const needsData1 = needsData2 || status === 0xf1 || status === 0xf3;
+    if (needsData1 && data1 > 0x7f) {
+      throw new RangeError("System data1 out of range");
+    }
+    if (needsData2 && data2 > 0x7f) {
+      throw new RangeError("System data2 out of range");
+    }
     const event: Midi2SystemEvent = {
       kind: "system",
       group,
@@ -1247,9 +1266,8 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
 
   switch (status) {
     case STATUS_RPN: {
-      if (dataMsb >= 0x80 || dataLsb >= 0x80) {
-        return null;
-      }
+      assertDecodeRange("rpn bank", dataMsb, 0, 0x7f);
+      assertDecodeRange("rpn index", dataLsb, 0, 0x7f);
       const event: Midi2RpnEvent = {
         kind: "rpn",
         group,
@@ -1262,9 +1280,8 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     case STATUS_NRPN: {
-      if (dataMsb >= 0x80 || dataLsb >= 0x80) {
-        return null;
-      }
+      assertDecodeRange("nrpn bank", dataMsb, 0, 0x7f);
+      assertDecodeRange("nrpn index", dataLsb, 0, 0x7f);
       const event: Midi2NrpnEvent = {
         kind: "nrpn",
         group,
@@ -1277,9 +1294,8 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     case STATUS_RPN_RELATIVE: {
-      if (dataMsb >= 0x80 || dataLsb >= 0x80) {
-        return null;
-      }
+      assertDecodeRange("rpn bank", dataMsb, 0, 0x7f);
+      assertDecodeRange("rpn index", dataLsb, 0, 0x7f);
       const event: Midi2RpnRelativeEvent = {
         kind: "rpnRelative",
         group,
@@ -1292,9 +1308,8 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     case STATUS_NRPN_RELATIVE: {
-      if (dataMsb >= 0x80 || dataLsb >= 0x80) {
-        return null;
-      }
+      assertDecodeRange("nrpn bank", dataMsb, 0, 0x7f);
+      assertDecodeRange("nrpn index", dataLsb, 0, 0x7f);
       const event: Midi2NrpnRelativeEvent = {
         kind: "nrpnRelative",
         group,
@@ -1307,6 +1322,7 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     case STATUS_NOTE_ON: {
+      assertDecodeRange("note", dataMsb, 0, 0x7f);
       const velocity = (dataWord >>> 16) & 0xffff;
       const attributeData = dataWord & 0xffff;
       const event: Midi2NoteOnEvent = {
@@ -1322,6 +1338,7 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     case STATUS_NOTE_OFF: {
+      assertDecodeRange("note", dataMsb, 0, 0x7f);
       const velocity = (dataWord >>> 16) & 0xffff;
       const attributeData = dataWord & 0xffff;
       const event: Midi2NoteOffEvent = {
@@ -1337,6 +1354,7 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     case STATUS_POLY_PRESSURE: {
+      assertDecodeRange("note", dataMsb, 0, 0x7f);
       const event: Midi2PolyPressureEvent = {
         kind: "polyPressure",
         group,
@@ -1348,6 +1366,7 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     case STATUS_CONTROL_CHANGE: {
+      assertDecodeRange("controller", dataMsb, 0, 0x7f);
       const event: Midi2ControlChangeEvent = {
         kind: "controlChange",
         group,
@@ -1359,6 +1378,7 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     case STATUS_PROGRAM_CHANGE: {
+      assertDecodeRange("program", dataMsb, 0, 0x7f);
       const bankValid = (dataLsb & 0x80) !== 0;
       const bankMsb = bankValid ? (dataWord >>> 24) & 0xff : undefined;
       const bankLsb = bankValid ? (dataWord >>> 16) & 0xff : undefined;
@@ -1397,6 +1417,7 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       if (packet.length < 2) {
         return null;
       }
+      assertDecodeRange("note", dataMsb, 0, 0x7f);
       if (dataWord === 0) {
         const event: Midi2PerNoteManagementEvent = {
           kind: "perNoteManagement",
@@ -1445,10 +1466,6 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
       return event;
     }
     default:
-      return {
-        kind: "rawUMP",
-        words: packet,
-        timestamp,
-      } as RawUMPEvent;
+      throw new RangeError(`Unsupported MIDI 2.0 channel voice status 0x${status.toString(16)}`);
   }
 }


### PR DESCRIPTION
## Summary
- add MuidManager for Swift/TS with conflict/expiry handling
- tighten flex validation (tempo range, text/accent lengths, reserved status rejection) across Swift/TS
- expand negative coverage and update spec docs/gap tracker

## Testing
- swift test --filter MuidManagerTests
- swift test --filter FlexValidationNegativeTests
- cd midi2.js && npm test -- flex-negative flex-reserved-negative negative muid-manager