### PR TITLE
test: expand midi2 channel voice negatives

### DIFF
--- a/Tests/MIDI2Tests/NegativeTests/Midi2ChannelVoiceNegativeTests.swift
+++ b/Tests/MIDI2Tests/NegativeTests/Midi2ChannelVoiceNegativeTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import MIDI2
+
+final class Midi2ChannelVoiceNegativeTests: XCTestCase {
+    func testInvalidStatusNibbleReturnsNil() {
+        // Status nibble 0x7 is undefined for MIDI 2.0 Channel Voice
+        let word0: UInt32 = (0x4 << 28) | (0x0 << 24) | (0x7 << 20)
+        let pkt = UmpPacket64(word0: word0, word1: 0)
+        XCTAssertNotNil(Midi2ChannelVoiceBody(ump: pkt)) // structural parse succeeds
+        XCTAssertNil(Midi2ChannelVoiceVariants(ump: pkt)) // typed variant rejects unknown status
+    }
+
+    func testNoteOnRejectsNoteAbove7Bit() {
+        // note=0xFF should fail validation
+        let word0: UInt32 = (0x4 << 28) | (0x0 << 24) | (0x9 << 20) | (0x0 << 16) | (0xFF << 8)
+        let pkt = UmpPacket64(word0: word0, word1: 0)
+        XCTAssertNil(Midi2NoteOn(ump: pkt))
+    }
+
+    func testPerNoteManagementRejectsInvalidNote() {
+        // per-note management with note=0xFF
+        let word0: UInt32 = (0x4 << 28) | (0x0 << 24) | (0xF << 20) | (0x0 << 16) | (0xFF << 8)
+        let pkt = UmpPacket64(word0: word0, word1: 0)
+        XCTAssertNil(Midi2PerNoteManagement(ump: pkt))
+    }
+}

--- a/docs/negative-test-matrix.md
+++ b/docs/negative-test-matrix.md
@@ -21,6 +21,7 @@
 | MIDI 1 Ch Voice – Data bounds | MIDI 1.0 | Data bytes >0x7F, invalid statuses | Rejected (Swift + TS) |
 | MIDI 2 Ch Voice – Unsupported status/data | M2-104-UM §7 | Status nibble undefined; note/controller > 0x7F | Rejected (Swift decode nil; TS RangeError) |
 | MIDI 2 System – Unsupported status/data | M2-104-UM §5.2 | Status outside allowed set; data1/data2 > 0x7F | Rejected (Swift decode nil; TS RangeError) |
+| MIDI 2 Per-note Management – Invalid note | M2-104-UM §7.4 | Note > 0x7F | Rejected (Swift decode nil) |
 | MIDI-CI Profiles – Channel/target bounds | M2-102-U v1.1 | Channel count overflow; invalid target nibble | Rejected (Swift decode nil/empty; TS envelope drops) |
 | Process Inquiry – messageDataControl | M2-101-UM v1.2 | messageDataControl not in {0x00,0x01,0x7F} | Rejected (Swift + TS) |
 

--- a/midi2.js/README.md
+++ b/midi2.js/README.md
@@ -115,6 +115,12 @@ console.log(r.manufacturerId, r.payload);
 
 ---
 
+## 6. Tests
+
+Run the TypeScript suite with `npm test` inside `midi2.js/` (vitest); CI jobs `build-test` and `test` mirror this.
+
+---
+
 ## 5. WebAudio Adapter
 
 ```ts


### PR DESCRIPTION
## Summary
- add Swift negative coverage for unsupported MIDI 2.0 channel voice status nibble and out-of-range notes
- document new negative cases in the matrix (per-note management invalid note)

## Testing
- swift test --filter Midi2ChannelVoiceNegativeTests