### PR TITLE
test: add per-note invalid note negatives (TS+Swift)

### DIFF
--- a/Tests/MIDI2Tests/NegativeTests/Midi2ChannelVoiceNegativeTests.swift
+++ b/Tests/MIDI2Tests/NegativeTests/Midi2ChannelVoiceNegativeTests.swift
@@ -23,4 +23,10 @@ final class Midi2ChannelVoiceNegativeTests: XCTestCase {
         let pkt = UmpPacket64(word0: word0, word1: 0)
         XCTAssertNil(Midi2PerNoteManagement(ump: pkt))
     }
+
+    func testPerNoteAssignableControllerRejectsInvalidNote() {
+        let word0: UInt32 = (0x4 << 28) | (0x0 << 24) | (0xF << 20) | (0x0 << 16) | (0xFF << 8) | UInt32(0x80)
+        let pkt = UmpPacket64(word0: word0, word1: 0)
+        XCTAssertNil(Midi2AssignPerNoteController(ump: pkt))
+    }
 }

--- a/docs/negative-test-matrix.md
+++ b/docs/negative-test-matrix.md
@@ -19,7 +19,7 @@
 | MIDI-CI Profiles Details (targets) | M2-102-U v1.1 Table 6 | Target missing on setOn/Off; channel count overflow | Rejected (Swift drops request) |
 | Flex – Reserved status class | Flex spec | Status class ≠ 0x10 | Rejected (Swift + TS) |
 | MIDI 1 Ch Voice – Data bounds | MIDI 1.0 | Data bytes >0x7F, invalid statuses | Rejected (Swift + TS) |
-| MIDI 2 Ch Voice – Unsupported status/data | M2-104-UM §7 | Status nibble undefined; note/controller > 0x7F | Rejected (Swift decode nil; TS RangeError) |
+| MIDI 2 Ch Voice – Unsupported status/data | M2-104-UM §7 | Status nibble undefined; note/controller > 0x7F; per-note assignable invalid note | Rejected (Swift decode nil; TS RangeError) |
 | MIDI 2 System – Unsupported status/data | M2-104-UM §5.2 | Status outside allowed set; data1/data2 > 0x7F | Rejected (Swift decode nil; TS RangeError) |
 | MIDI 2 Per-note Management – Invalid note | M2-104-UM §7.4 | Note > 0x7F | Rejected (Swift decode nil) |
 | MIDI-CI Profiles – Channel/target bounds | M2-102-U v1.1 | Channel count overflow; invalid target nibble | Rejected (Swift decode nil/empty; TS envelope drops) |

--- a/midi2.js/src/__tests__/negative.test.ts
+++ b/midi2.js/src/__tests__/negative.test.ts
@@ -11,8 +11,18 @@ describe("negative decode coverage (reserved/invalid values)", () => {
     expect(decode([word0, 0])).toThrow(RangeError);
   });
 
+  it("rejects MIDI 2 channel voice per-note assignable controller with note above 0x7F", () => {
+    const word0 = (0x4 << 28) | (0x0 << 24) | (0xf << 20) | (0x0 << 16) | (0xff << 8) | 0x80;
+    expect(decode([word0, 0])).toThrow(RangeError);
+  });
+
   it("rejects MIDI 2 channel voice per-note reg controller with note above 0x7F", () => {
     const word0 = (0x4 << 28) | (0x0 << 24) | (0xf << 20) | (0x0 << 16) | (0xff << 8) | 0x01;
+    expect(decode([word0, 0])).toThrow(RangeError);
+  });
+
+  it("rejects MIDI 2 channel voice per-note pitch bend with note above 0x7F", () => {
+    const word0 = (0x4 << 28) | (0x0 << 24) | (0x0 << 20) | (0x0 << 16) | (0xff << 8);
     expect(decode([word0, 0])).toThrow(RangeError);
   });
 


### PR DESCRIPTION
## Summary
- add per-note assignable/pitch-related invalid note negatives in TS vitest
- add Swift negatives for per-note assignable controller invalid note
- update negative test matrix entry for per-note coverage

## Testing
- swift test --filter Midi2ChannelVoiceNegativeTests
- cd midi2.js && npm test -- negative