### PR TITLE
test: extend per-note negative coverage

### DIFF
--- a/midi2.js/src/__tests__/fuzz-negative.test.ts
+++ b/midi2.js/src/__tests__/fuzz-negative.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { decodeUmp } from "../ump";
+
+function expectThrow(words: number[]) {
+  expect(() => decodeUmp(new Uint32Array(words.map(w => w >>> 0)))).toThrow();
+}
+
+describe("fuzzed invalid channel voice/status values", () => {
+  it("rejects random undefined channel-voice statuses", () => {
+    for (let i = 0; i < 100; i++) {
+      const group = Math.floor(Math.random() * 16) & 0xf;
+      const statusNibble = 0x7; // undefined for MIDI 2 channel voice
+      const word0 = (0x4 << 28) | (group << 24) | (statusNibble << 20);
+      expectThrow([word0, 0]);
+    }
+  });
+
+  // Additional fuzz cases can be added as decoding guards expand.
+});


### PR DESCRIPTION
## Summary
- add TS vitest negative for per-note assignable with invalid note and lightweight fuzz for undefined channel-voice status
- add Swift negative for per-note assignable invalid note
- update negative-test matrix entries

## Testing
- swift test --filter Midi2ChannelVoiceNegativeTests
- cd midi2.js && npm test -- negative
- cd midi2.js && npm test -- fuzz-negative