### PR TITLE
test: add sysex reserved negatives

### DIFF
--- a/Tests/MIDI2Tests/NegativeTests/StreamNegativeTests.swift
+++ b/Tests/MIDI2Tests/NegativeTests/StreamNegativeTests.swift
@@ -37,4 +37,23 @@ final class StreamNegativeValidationTests: XCTestCase {
         XCTAssertThrowsError(try SysEx7.fragment(manufacturerID: [0x7D], payload: oversized))
         XCTAssertThrowsError(try SysEx8.fragment(manufacturerID: [0x7D], payload: oversized))
     }
+
+    func testSysEx7RejectsInvalidStatusAndChunkCount() {
+        let invalidStatus = Array([UInt8(0x30), 0x40] + Array(repeating: UInt8(0), count: 6))
+        XCTAssertThrowsError(try SysEx7.reassemble([invalidStatus]))
+
+        let badCount = Array([UInt8(0x30), 0x17] + Array(repeating: UInt8(0), count: 6)) // count nibble 7 > maxChunk
+        XCTAssertThrowsError(try SysEx7.reassemble([badCount]))
+
+        let emptyPayload = Array([UInt8(0x30), 0x00] + Array(repeating: UInt8(0), count: 6)) // no data bytes present
+        XCTAssertThrowsError(try SysEx7.reassemble([emptyPayload]))
+    }
+
+    func testSysEx8RejectsInvalidStatusAndEmptyPayload() {
+        let invalidStatus = Array([UInt8(0x50), 0x40] + Array(repeating: UInt8(0), count: 14))
+        XCTAssertThrowsError(try SysEx8.reassemble([invalidStatus]))
+
+        let emptyPayload = Array([UInt8(0x50), 0x00] + Array(repeating: UInt8(0), count: 14))
+        XCTAssertThrowsError(try SysEx8.reassemble([emptyPayload]))
+    }
 }

--- a/docs/negative-test-matrix.md
+++ b/docs/negative-test-matrix.md
@@ -11,6 +11,7 @@
 | Stream – Reserved bit in mt=0xF word | M2-104-UM §5.1 | Low reserved bit set | Rejected (TS) |
 | Utility – Groupless + status | M2-104-UM §5.1 | Group nibble non-zero; unsupported status | Rejected (Swift + TS) |
 | SysEx7/SysEx8 – Oversize payload | M2-104-UM §4.2 | Payload > 0xFFFF | Rejected (Swift + TS) |
+| SysEx7/SysEx8 – Invalid status/count/empty | M2-104-UM §4.2 | Status nibble outside 0–3; count nibble > max; empty payload | Rejected (Swift + TS) |
 | Flex – Tempo / Time Signature | Flex spec | BPM < 1; denominatorPow2 > 0x1F | Rejected (TS; Swift validated via throwing inits) |
 | Flex – Payload bounds | Flex spec | Tempo > 16.16 max; text/ruby/lyric/chord/key >12 bytes; metronome accent >10 bytes | Rejected (Swift + TS) |
 | Flex – Unknown status within class | Flex spec | Unrecognised status values in class 0x10/0x11 | Rejected (Swift + TS) |
@@ -26,8 +27,7 @@
 | Process Inquiry – messageDataControl | M2-101-UM v1.2 | messageDataControl not in {0x00,0x01,0x7F} | Rejected (Swift + TS) |
 
 ## Next Targets
-- SysEx8/SysEx7 reserved/oversize edge cases (already partially covered; add matrix entries).
-- Utility reserved opcodes and out-of-range fields.
+- Utility reserved opcodes and out-of-range fields (beyond group/status already covered).
 - MIDI-CI Process Inquiry/profile/detail negative cases.
 
 ## Usage Notes

--- a/midi2.js/src/__tests__/negative.test.ts
+++ b/midi2.js/src/__tests__/negative.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { decodeUmp } from "../ump";
+import { reassembleSysEx7, reassembleSysEx8, umpBytesToWords } from "../sysex";
 
 function decode(words: number[]) {
   return () => decodeUmp(new Uint32Array(words.map(w => w >>> 0)));
@@ -81,5 +82,24 @@ describe("negative decode coverage (reserved/invalid values)", () => {
   it("rejects MIDI 2 system with unsupported status", () => {
     const word0 = (0x1 << 28) | (0x0 << 24) | (0xf4 << 16);
     expect(decode([word0])).toThrow(RangeError);
+  });
+
+  it("rejects SysEx7 packets with invalid status, oversize chunk, or empty payload", () => {
+    const invalidStatus = [umpBytesToWords(Uint8Array.from([0x30, 0x40, 0, 0, 0, 0, 0, 0]))];
+    expect(() => reassembleSysEx7(invalidStatus)).toThrow(RangeError);
+
+    const oversizeCount = [umpBytesToWords(Uint8Array.from([0x30, 0x17, 0, 0, 0, 0, 0, 0]))]; // count nibble 7 > 6
+    expect(() => reassembleSysEx7(oversizeCount)).toThrow(RangeError);
+
+    const emptyPayload = [umpBytesToWords(Uint8Array.from([0x30, 0x00, 0, 0, 0, 0, 0, 0]))];
+    expect(() => reassembleSysEx7(emptyPayload)).toThrow(RangeError);
+  });
+
+  it("rejects SysEx8 packets with invalid status or empty payload", () => {
+    const invalidStatus = [umpBytesToWords(Uint8Array.from([0x50, 0x40, ...Array(14).fill(0)]))];
+    expect(() => reassembleSysEx8(invalidStatus)).toThrow(RangeError);
+
+    const emptyPayload = [umpBytesToWords(Uint8Array.from([0x50, 0x00, ...Array(14).fill(0)]))];
+    expect(() => reassembleSysEx8(emptyPayload)).toThrow(RangeError);
   });
 });


### PR DESCRIPTION
## Summary
- add Swift negative tests for SysEx7/8 invalid status/count and empty payload
- add TS negative cases hitting reassembly for invalid status/count and empty payload
- document coverage in the negative test matrix

## Testing
- swift test --filter StreamNegativeValidationTests
- npm test -- negative