### PR TITLE
test: enforce utility noop reserved payload

### DIFF
--- a/Sources/MIDI2/System/Utility.swift
+++ b/Sources/MIDI2/System/Utility.swift
@@ -39,6 +39,7 @@ public enum Utility: Equatable {
         let data = UInt16(ump.word & 0xFFFF)
         switch status {
         case 0x00:
+            guard data == 0 else { return nil } // reserved payload must be zero
             self = .noop
         case 0x01:
             self = .jrClock(data)
@@ -62,6 +63,9 @@ public enum Utility: Equatable {
         let data = UInt16(ump.word & 0xFFFF)
         switch status {
         case 0x00:
+            guard data == 0 else {
+                throw MIDIError.malformedPacket("utility noop must carry zero data")
+            }
             self = .noop
         case 0x01:
             self = .jrClock(data)

--- a/Tests/MIDI2Tests/System/UtilityErrorTests.swift
+++ b/Tests/MIDI2Tests/System/UtilityErrorTests.swift
@@ -19,4 +19,13 @@ final class UtilityErrorTests: XCTestCase {
             XCTAssertTrue(error.localizedDescription.contains("group nibble"))
         }
     }
+
+    func testNoopMustHaveZeroPayload() {
+        let byte0 = UInt32(0x0 << 4)
+        let word = (byte0 << 24) | (UInt32(0x00) << 16) | 0x1234
+        let ump = UmpPacket32(word: word)
+        XCTAssertThrowsError(try Utility(parsingUMP: ump)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("zero data"))
+        }
+    }
 }

--- a/docs/negative-test-matrix.md
+++ b/docs/negative-test-matrix.md
@@ -10,6 +10,7 @@
 | Stream – Function Block Info | M2-104-UM Fig.22 | Reserved `midi1Bandwidth=3`, reserved bits | Rejected (Swift + TS) |
 | Stream – Reserved bit in mt=0xF word | M2-104-UM §5.1 | Low reserved bit set | Rejected (TS) |
 | Utility – Groupless + status | M2-104-UM §5.1 | Group nibble non-zero; unsupported status | Rejected (Swift + TS) |
+| Utility – No-op payload | M2-104-UM §5.1 | No-op carrying non-zero data | Rejected (Swift + TS) |
 | SysEx7/SysEx8 – Oversize payload | M2-104-UM §4.2 | Payload > 0xFFFF | Rejected (Swift + TS) |
 | SysEx7/SysEx8 – Invalid status/count/empty | M2-104-UM §4.2 | Status nibble outside 0–3; count nibble > max; empty payload | Rejected (Swift + TS) |
 | Flex – Tempo / Time Signature | Flex spec | BPM < 1; denominatorPow2 > 0x1F | Rejected (TS; Swift validated via throwing inits) |

--- a/midi2.js/src/__tests__/negative.test.ts
+++ b/midi2.js/src/__tests__/negative.test.ts
@@ -102,4 +102,9 @@ describe("negative decode coverage (reserved/invalid values)", () => {
     const emptyPayload = [umpBytesToWords(Uint8Array.from([0x50, 0x00, ...Array(14).fill(0)]))];
     expect(() => reassembleSysEx8(emptyPayload)).toThrow(RangeError);
   });
+
+  it("rejects utility noop with non-zero payload", () => {
+    const word0 = (0x0 << 28) | (0x00 << 16) | 0x1234;
+    expect(decode([word0])).toThrow(RangeError);
+  });
 });

--- a/midi2.js/src/ump.ts
+++ b/midi2.js/src/ump.ts
@@ -164,6 +164,9 @@ function encodeUtility(event: UtilityEvent): Uint32Array {
   let data = 0;
   switch (event.status) {
     case "noop":
+      if ((event.value ?? 0) !== 0) {
+        throw new RangeError("Utility noop must have zero value.");
+      }
       statusByte = 0x00;
       data = 0;
       break;
@@ -1186,6 +1189,9 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
     else if (statusByte === 0x01) status = "jrClock";
     else if (statusByte === 0x02) status = "jrTimestamp";
     else throw new RangeError("Unsupported utility status");
+    if (status === "noop" && value !== 0) {
+      throw new RangeError("Utility noop must have zero payload.");
+    }
     const event: UtilityEvent = {
       kind: "utility",
       status,


### PR DESCRIPTION
## Summary
- enforce Utility noop payload=0 in Swift decode and TypeScript decode/encode
- add negative tests for noop with non-zero payload
- document Utility noop reserved payload in the negative test matrix

## Testing
- swift test --filter UtilityErrorTests
- cd midi2.js && npm test -- negative