### PR TITLE
test: reject reserved UMP message types

### DIFF
--- a/docs/negative-test-matrix.md
+++ b/docs/negative-test-matrix.md
@@ -13,6 +13,7 @@
 | Utility – No-op payload | M2-104-UM §5.1 | No-op carrying non-zero data | Rejected (Swift + TS) |
 | SysEx7/SysEx8 – Oversize payload | M2-104-UM §4.2 | Payload > 0xFFFF | Rejected (Swift + TS) |
 | SysEx7/SysEx8 – Invalid status/count/empty | M2-104-UM §4.2 | Status nibble outside 0–3; count nibble > max; empty payload | Rejected (Swift + TS) |
+| UMP Message Type – Reserved nibble | M2-104-UM §5 | MT outside {0,1,2,3,4,5,13,15} | Rejected (TS) |
 | Flex – Tempo / Time Signature | Flex spec | BPM < 1; denominatorPow2 > 0x1F | Rejected (TS; Swift validated via throwing inits) |
 | Flex – Payload bounds | Flex spec | Tempo > 16.16 max; text/ruby/lyric/chord/key >12 bytes; metronome accent >10 bytes | Rejected (Swift + TS) |
 | Flex – Unknown status within class | Flex spec | Unrecognised status values in class 0x10/0x11 | Rejected (Swift + TS) |

--- a/midi2.js/src/__tests__/negative.test.ts
+++ b/midi2.js/src/__tests__/negative.test.ts
@@ -107,4 +107,9 @@ describe("negative decode coverage (reserved/invalid values)", () => {
     const word0 = (0x0 << 28) | (0x00 << 16) | 0x1234;
     expect(decode([word0])).toThrow(RangeError);
   });
+
+  it("rejects unsupported UMP message type nibble", () => {
+    const unsupportedMt = (0x6 << 28) | 0x000000;
+    expect(decode([unsupportedMt])).toThrow(RangeError);
+  });
 });

--- a/midi2.js/src/__tests__/ump.test.ts
+++ b/midi2.js/src/__tests__/ump.test.ts
@@ -216,13 +216,9 @@ describe("UMP channel voice encode/decode", () => {
     expect(decoded).toMatchObject(evt);
   });
 
-  it("passes through unknown message types as raw UMP", () => {
+  it("rejects unknown message types", () => {
     const words = new Uint32Array([0xe0000000, 0x01020304]);
-    const decoded = decodeUmp(words);
-    expect(decoded).toMatchObject({
-      kind: "rawUMP",
-      words,
-    });
+    expect(() => decodeUmp(words)).toThrow(RangeError);
   });
 
   it("encodes and decodes system common/realtime", () => {

--- a/midi2.js/src/ump.ts
+++ b/midi2.js/src/ump.ts
@@ -959,6 +959,10 @@ export function decodeUmp(words: ArrayLike<number>, timestamp?: number): Midi2Ev
   const packet = toUint32Array(words);
   const word0 = packet[0];
   const mt = (word0 >>> 28) & 0xf;
+  const supportedMt = new Set([UTILITY_MT, MIDI2_SYSTEM_MT, MIDI1_CHANNEL_VOICE_MT, 0x3, MIDI2_CHANNEL_VOICE_MT, 0x5, 0xd, STREAM_MT]);
+  if (!supportedMt.has(mt)) {
+    throw new RangeError(`Unsupported UMP message type 0x${mt.toString(16)}`);
+  }
   if (mt === STREAM_MT) {
     return decodeStream(packet, timestamp);
   }


### PR DESCRIPTION
## Summary
- enforce RangeError when decoding UMP packets with reserved/unsupported message type nibble
- add TS negative test for unsupported MT and document in the negative test matrix

## Testing
- cd midi2.js && npm test -- negative