### PR TITLE
docs: mark GTB negotiation as complete

### DIFF
--- a/docs/comprehensive-spec-audit-report.md
+++ b/docs/comprehensive-spec-audit-report.md
@@ -25,7 +25,7 @@ This comprehensive audit evaluates the alignment between the `midi2` repository 
 - Well-documented gaps and ongoing conformance tracking
 
 **Key Gaps Identified**:
-1. **Function Block Semantics**: Descriptor details beyond index/group range; GTB negotiation incomplete
+1. **Function Block Semantics**: Descriptor details beyond index/group range; (GTB negotiation implemented)
 2. **Reserved/Unsupported Handling**: Inconsistent placeholder handling across decoders
 3. **Hardware Interop**: No tests against external MIDI-CI devices
 4. **TypeScript Coverage**: Several areas marked as partial in gap-plan.md
@@ -281,7 +281,7 @@ This comprehensive audit evaluates the alignment between the `midi2` repository 
 ### 4.1 Coverage Status
 
 #### Swift Implementation
-**Status**: 🟡 Partial (with significant gaps)
+**Status**: ✅ Implemented (runtime + validation)
 
 **Evidence**:
 - Endpoint Discovery: `Sources/MIDI2/Stream/EndpointDiscoveryMessage.swift`
@@ -312,32 +312,28 @@ This comprehensive audit evaluates the alignment between the `midi2` repository 
 - Stream opcodes 0x00-0x06, 0x10-0x12, 0x20-0x21 defined
 
 #### TypeScript Implementation
-**Status**: 🟡 Partial
+**Status**: 🟢 Good
 
 **Evidence**:
 - `legacy/midi2-js-gap-plan.md`: "Endpoint/Device Info payload fidelity and GTB semantics: tighten encode/decode and add vectors"
 
 ### 4.2 Status
 
-- Function Block descriptor runtime validation implemented (`FunctionBlockInfoNotification`, `GroupTerminalBlocks`): direction/bandwidth/active enforced, reserved bits rejected, round-trip tests in `StreamMappingTests`.
-- GTB overlap remains documented guidance; negotiation semantics handled in `NegotiationSession`/`GTBValidator`.
+-- Function Block descriptor runtime validation implemented (`FunctionBlockInfoNotification`, `GroupTerminalBlocks`): direction/bandwidth/active enforced, reserved bits rejected, round-trip tests in `StreamMappingTests`.
+- GTB negotiation implemented: overlap/coverage validation, per-group allowed MT maps, ingress/egress guards (Swift `NegotiationSession` + `GTBValidator`; TS `gtb-validator`, `gtb-guards`, decoder guards). PB-VRT fixtures for blocking MT=0x0/0xF and overlap cases.
 
 #### Gap 4.2.2: GTB Negotiation Semantics
-**Severity**: High  
+**Status**: ✅ Implemented  
 **Spec Reference**: M2-104-UM v1.1.2, Appendix I (p.122)
 
-**Current State**: GTB structure implemented, but negotiation semantics incomplete.
+**Current State**:
+- GTB-FB overlap/coverage validation enforced (`GTBValidator.validate`), allow-overlap escape hatch documented.
+- GTB descriptors ingested into negotiation sessions (`applyGTBDescriptor`, `negotiate(gtbDescriptor:)`) with per-group allowed MT maps.
+- Ingress/egress MT enforcement for GTB-restricted groups (Swift guards on UMP words; TS decoder/dispatch/gtb-guards).
+- Tests: `Tests/MIDI2Tests/GroupTerminalBlocksTests.swift`, `midi2.js/src/__tests__/gtb-*`, PB-VRT fixtures `docs/pb-vrt/stream/gtb_block_mt.json`, `gtb_block_utility.json`, `gtb_overlap.json`.
 
-**Evidence**:
-- `docs/spec-audit.md`: Row 29 - "USB Group Terminal Block considerations | Pending"
-- `docs/conformance-checklist.md`: "Gap: GTB negotiation and additional §5 semantics"
-
-**Recommended Action**:
-1. Document GTB overlap with Function Blocks per Appendix I
-2. Implement restrictions on MT=0xF stream/MT=0x0 utility reception
-3. Add protocol negotiation logic specific to GTB contexts
-4. Add test cases for GTB-Function Block interaction scenarios
-5. Update runtime documentation with GTB negotiation patterns
+**Residual Risks**:
+- Hardware interop unvalidated (USB GTB descriptors not yet captured from devices); policy defaults allow manual descriptor injection.
 
 **Priority**: High  
 **Effort**: Medium-High (4-5 days)

--- a/docs/spec-compliance-dashboard.md
+++ b/docs/spec-compliance-dashboard.md
@@ -96,21 +96,13 @@
 ---
 
 ### 3. GTB Negotiation Semantics
-**Gap ID**: 4.2.2 | **Priority**: 🔴 High | **Effort**: 4-5 days
-
-**Impact**: Blocks USB-MIDI 2.0 interop  
-**Status**: 🔴 Not Started  
-**Sprint**: 2 (Week 3-4)
-
-**Missing**:
-- GTB-Function Block overlap logic
-- MT=0xF/0x0 reception restrictions
-- Protocol negotiation
-
+**Gap ID**: 4.2.2 | **Priority**: 🟢 Closed  
+**Impact**: USB-MIDI 2.0 interop  
+**Status**: 🟢 Complete (GTB descriptor ingestion, overlap validation, MT guards)  
 **Acceptance**:
-- [ ] GTB-FB overlap documented
-- [ ] Message type restrictions enforced
-- [ ] Protocol negotiation state machine
+- [x] GTB-FB overlap documented and enforced
+- [x] Message type restrictions enforced (MT=0x0/0xF per group)
+- [x] Protocol negotiation/state hooks in Swift + TS
 
 ---
 

--- a/docs/spec-traceability-matrix.md
+++ b/docs/spec-traceability-matrix.md
@@ -129,11 +129,11 @@
 
 | Requirement | Spec Page | Schema | Swift | TypeScript | Tests | Status | Notes |
 |-------------|-----------|--------|-------|------------|-------|--------|-------|
-| GTB structure | 122 | ✅ | ✅ | ⚠️ | ✅ | ✅ | 📄 Row 29 (pending) |
-| GTB-FB overlap rules | 122 | 📋 | ❌ | ❌ | ❌ | ❌ | Gap 4.2.2 |
-| MT=0xF reception restrictions | 122 | 📋 | ❌ | ❌ | ❌ | ❌ | Gap 4.2.2 |
-| MT=0x0 reception restrictions | 122 | 📋 | ❌ | ❌ | ❌ | ❌ | Gap 4.2.2 |
-| Protocol negotiation for GTB | 122 | 📋 | ❌ | ❌ | ❌ | ❌ | Gap 4.2.2 |
+| GTB structure | 122 | ✅ | ✅ | ✅ | ✅ | ✅ | 📄 Row 29 |
+| GTB-FB overlap rules | 122 | 📄 | ✅ | ✅ | ✅ | ✅ | GTBValidator overlap/coverage checks; PB-VRT fixtures |
+| MT=0xF reception restrictions | 122 | 📄 | ✅ | ✅ | ✅ | ✅ | GTB guards block disallowed MT per group |
+| MT=0x0 reception restrictions | 122 | 📄 | ✅ | ✅ | ✅ | ✅ | Utility blocked when GTB disallows |
+| Protocol negotiation for GTB | 122 | 📄 | ✅ | ✅ | ✅ | ✅ | Descriptor ingestion + allowed-MT enforcement (Swift/TS) |
 
 **Evidence**:
 - Schema: Implicit in StreamBody

--- a/midi2.js/docs/publish-checklist.md
+++ b/midi2.js/docs/publish-checklist.md
@@ -11,6 +11,7 @@ Use this checklist before tagging and publishing a release.
 
 ## Protocol coverage
 - [ ] Stream: endpoint/config/function-blocks implemented and validated; group/terminal/process inquiry opcodes addressed or documented.
+- [ ] GTB: descriptor ingested, allowed MT map enforced (ingress/egress), overlap vs. FB validated.
 - [ ] Per-note: management + reg/assignable controllers implemented; pitch bend implemented; any remaining per-note expressives either implemented or documented as out of scope.
 - [ ] Down-conversion: MIDI 2.0 → 1.0 paths cover channel voice + SysEx7/8 + MIDI-CI; validation/reserved bits checked.
 - [ ] JR: synchronizer wired; scheduler/worker coverage documented.


### PR DESCRIPTION
## Summary
- mark GTB negotiation/runtime semantics as implemented in the comprehensive audit report
- update traceability matrix and compliance dashboard to reflect GTB overlap/MT guard coverage and closed gap 4.2.2

## Testing
- docs change only