### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- _Nothing yet._
+
+## [0.9.0] - 2025-12-16
 ### Changed
 - Docs: Comprehensive documentation audit - updated test counts (198 TS tests), version references (0.8.0), gap-closure status (10/21 complete), and archived legacy docs with proper cross-references.
 - Docs: Updated SECURITY.md supported versions to reflect v0.8.x as current stable.

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version: 6.1
 import PackageDescription
 
-let packageVersion = "0.8.0"
+let packageVersion = "0.9.0"
 
 let package = Package(
     name: "MIDI2",

--- a/midi2.js/package-lock.json
+++ b/midi2.js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fountain-coach/midi2",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fountain-coach/midi2",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.9.0",

--- a/midi2.js/package.json
+++ b/midi2.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fountain-coach/midi2",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": false,
   "description": "Cross-browser, CoreMIDI-free MIDI 2.0 protocol and scheduler core.",
   "license": "MIT",


### PR DESCRIPTION
Bump repo versions for v0.9.0 release.

Changes:
- set Swift packageVersion to 0.9.0
- bump midi2.js package.json/package-lock to 0.9.0 via npm version
- move latest notes into CHANGELOG under 0.9.0 and clear Unreleased placeholder

Tests: not run (docs/version bump only)