### PR TITLE
FCIS RFC 0001 compliance

### DIFF
--- a/.codex/skills/ci-operations/SKILL.md
+++ b/.codex/skills/ci-operations/SKILL.md
@@ -1,0 +1,24 @@
+# CI Operations
+
+## Purpose
+Maintain CI reliability, required status checks, and build matrix health.
+
+## When to Use
+- CI failures on `main` or active PRs
+- Monthly review of workflows and runner versions
+- Dependabot updates affecting GitHub Actions
+
+## Steps
+1. Monitor workflow runs and identify failures or flaky tests.
+2. Investigate root causes and fix or re-run as needed.
+3. Update workflow dependencies and runner versions when required.
+4. Confirm required checks for `main` are enforced.
+
+## Output Contract
+- CI passes on `main` and for active PRs.
+- Workflow dependencies are current and stable.
+- Required status checks remain enforced.
+
+## References
+- `.github/workflows/*` for pipeline definitions.
+- `MAINTENANCE.md` for command-level procedures.

--- a/.codex/skills/dependency-maintenance/SKILL.md
+++ b/.codex/skills/dependency-maintenance/SKILL.md
@@ -1,0 +1,25 @@
+# Dependency Maintenance
+
+## Purpose
+Keep dependencies up to date and respond to security advisories with minimal risk.
+
+## When to Use
+- Weekly dependabot review
+- Security alerts or CVE responses
+- Scheduled monthly dependency audits
+
+## Steps
+1. Review Dependabot PRs and categorize by patch/minor/major impact.
+2. Verify CI results before approving merges.
+3. For manual updates, update dependencies and run relevant tests.
+4. Document significant dependency changes in `CHANGELOG.md`.
+5. Prioritize critical/high security fixes per SLA.
+
+## Output Contract
+- Dependency updates are merged with passing CI.
+- High-risk changes are reviewed and tested.
+- Security fixes meet SLA timelines.
+
+## References
+- `MAINTENANCE.md` for command-level procedures.
+- `.github/dependabot.yml` for configuration.

--- a/.codex/skills/deprecation-lifecycle/SKILL.md
+++ b/.codex/skills/deprecation-lifecycle/SKILL.md
@@ -1,0 +1,18 @@
+# Deprecation Lifecycle
+
+## Purpose
+Manage deprecations and breaking changes with clear timelines and migration guidance.
+
+## When to Use
+- Deprecating APIs or behavior
+- Planning a breaking change for a major version
+
+## Steps
+1. Announce deprecation in code comments and documentation.
+2. Maintain deprecated APIs for at least one minor version.
+3. Provide migration guidance in `CHANGELOG.md` and release notes.
+4. Remove deprecated APIs only in a major release.
+
+## Output Contract
+- Deprecations are announced and documented.
+- Migrations are documented and timed to major releases.

--- a/.codex/skills/maintenance-cadence/SKILL.md
+++ b/.codex/skills/maintenance-cadence/SKILL.md
@@ -1,0 +1,20 @@
+# Maintenance Cadence
+
+## Purpose
+Keep routine weekly/monthly/quarterly maintenance consistent and traceable.
+
+## When to Use
+- Weekly maintenance cycle
+- Monthly or quarterly audits
+
+## Steps
+1. Weekly: triage new issues/PRs, review dependabot PRs, check CI health, update `CHANGELOG.md` if needed.
+2. Monthly: dependency audit, CI review, documentation sync, release planning.
+3. Quarterly: security audit, performance review, documentation refresh, archival review, compliance review.
+
+## Output Contract
+- Routine maintenance tasks are completed or tracked with issues.
+- Dependency and security checks are up to date.
+
+## References
+- `MAINTENANCE.md` for detailed procedures.

--- a/.codex/skills/midi2-js-workflow/SKILL.md
+++ b/.codex/skills/midi2-js-workflow/SKILL.md
@@ -1,0 +1,26 @@
+# midi2.js Workflow
+
+## Purpose
+Keep the JavaScript/TypeScript library workflow consistent with tests, builds, and documentation expectations.
+
+## When to Use
+- Making changes under `midi2.js/`
+- Updating protocol surface area in the JS library
+
+## Steps
+1. Run type checks and tests:
+   - `npm run check`
+   - `npm test`
+2. Build artifacts when needed:
+   - `npm run build`
+3. Keep core logic platform-agnostic; adapters remain under `src/adapters/`.
+4. Update documentation and gap tracking when public APIs or protocol coverage change.
+
+## Output Contract
+- Tests and type checks pass for `midi2.js` changes.
+- Build artifacts are reproducible.
+- Docs and gap tracking remain aligned with API surface changes.
+
+## References
+- `midi2.js/README.md`
+- `docs/gap-closure-tracker.md`

--- a/.codex/skills/onboarding-maintainers/SKILL.md
+++ b/.codex/skills/onboarding-maintainers/SKILL.md
@@ -1,0 +1,22 @@
+# Onboarding Maintainers
+
+## Purpose
+Provide consistent onboarding for new maintainers with access, context, and initial tasks.
+
+## When to Use
+- Adding a new maintainer
+- Rotating on-call roles
+
+## Steps
+1. Confirm required access (repo write, npm publish, CODEOWNERS inclusion).
+2. Review key docs: `README.md`, `CONTRIBUTING.md`, `RELEASE.md`, `AGENTS.md`.
+3. Complete local setup and test runs for Swift and JavaScript.
+4. Shadow a Triage Lead or Release Manager for one cycle.
+5. Assign initial tasks (triage, reviews, weekly maintenance).
+
+## Output Contract
+- New maintainer has required access and context.
+- Initial tasks are assigned and completed.
+
+## References
+- `CONTRIBUTING.md` for local setup details.

--- a/.codex/skills/release-process/SKILL.md
+++ b/.codex/skills/release-process/SKILL.md
@@ -1,0 +1,25 @@
+# Release Process
+
+## Purpose
+Coordinate a versioned release across Swift and JavaScript packages with consistent changelog and tags.
+
+## When to Use
+- Preparing a scheduled release
+- Shipping a hotfix or emergency patch
+
+## Steps
+1. Confirm CI is green and coverage meets the required threshold.
+2. Update `CHANGELOG.md` from "Unreleased" into a versioned section.
+3. Bump versions in `Package.swift` and `midi2.js/package.json`.
+4. Build and test both Swift and JavaScript packages.
+5. Create and push a signed git tag for the release.
+6. Publish the npm package from `midi2.js/`.
+7. Draft and publish the GitHub Release.
+
+## Output Contract
+- Version numbers and changelog are updated.
+- Release tag exists and is pushed.
+- npm package and GitHub Release are published.
+
+## References
+- `RELEASE.md` for full step-by-step commands and checklists.

--- a/.codex/skills/security-incident-response/SKILL.md
+++ b/.codex/skills/security-incident-response/SKILL.md
@@ -1,0 +1,24 @@
+# Security Incident Response
+
+## Purpose
+Handle vulnerability reports with coordinated disclosure, timely patches, and clear communication.
+
+## When to Use
+- A security report arrives via advisories or email
+- Dependabot flags a critical/high vulnerability
+
+## Steps
+1. Acknowledge the report within 24 hours.
+2. Validate and assess severity.
+3. Develop and test a private fix.
+4. Coordinate disclosure timing with the reporter.
+5. Publish a patched release and advisory.
+6. Announce the resolution and update `SECURITY.md` if needed.
+
+## Output Contract
+- Severity is assessed and documented.
+- A patched release is published within SLA.
+- Security advisory and communication are complete.
+
+## References
+- `SECURITY.md` for reporting channels and timelines.

--- a/.codex/skills/spec-pdf-to-schema/SKILL.md
+++ b/.codex/skills/spec-pdf-to-schema/SKILL.md
@@ -1,0 +1,19 @@
+# Spec PDF to Schema Mapping
+
+## Purpose
+Ensure protocol facts derived from MIDI spec PDFs are reflected in canonical JSON schema/OpenAPI sources.
+
+## When to Use
+- Implementing protocol details sourced from PDF specifications
+- Updating schema or OpenAPI definitions
+
+## Steps
+1. Render the relevant PDF pages to images for inspection.
+2. Validate the bit layout or field definitions against the images.
+3. Update `midi2.full.closed.schema.json` and `midi2.full.openapi.json` with the verified facts.
+4. Implement code and tests only after schema/OpenAPI updates.
+5. Document the source page/section in related notes or audit docs.
+
+## Output Contract
+- Canonical JSON schema/OpenAPI reflect the PDF-derived facts.
+- Code/tests align with the updated canonical sources.

--- a/.codex/skills/sunsetting/SKILL.md
+++ b/.codex/skills/sunsetting/SKILL.md
@@ -1,0 +1,17 @@
+# Sunsetting and Archival
+
+## Purpose
+Retire packages or the repository responsibly when maintenance ends.
+
+## When to Use
+- Archival criteria are met (no commits for 12 months, maintainers vote, unpatchable vulnerability, or unsupported stack)
+
+## Steps
+1. Announce intent to archive with a 90-day notice.
+2. Publish a final release with end-of-life notice.
+3. Update README and docs with deprecation banner.
+4. Archive the repository and deprecate npm package if applicable.
+
+## Output Contract
+- Stakeholders are notified ahead of archival.
+- Final release and documentation reflect end-of-life status.

--- a/.codex/skills/triage-workflow/SKILL.md
+++ b/.codex/skills/triage-workflow/SKILL.md
@@ -1,0 +1,23 @@
+# Triage Workflow
+
+## Purpose
+Standardize issue and pull request triage so incoming work is labeled, prioritized, and routed consistently.
+
+## When to Use
+- New issues or PRs arrive
+- Weekly triage cadence
+- Security-related reports appear
+
+## Steps
+1. Validate the report has enough context and reproduction details.
+2. Apply type labels (`bug`, `enhancement`, `documentation`, `question`, `security`).
+3. Apply area labels (`area/swift`, `area/javascript`, `area/ci`, `area/docs`, `area/examples`).
+4. Apply priority (`priority/critical`, `priority/high`, `priority/normal`, `priority/low`).
+5. Assign or add to the appropriate milestone/backlog.
+6. For security reports, route to the Security Contact and restrict visibility.
+7. Apply staleness policy if applicable and add `keep-open` to exempt.
+
+## Output Contract
+- Issue/PR has correct labels and priority.
+- Ownership or next action is clear (assignee or milestone).
+- Security items are escalated and handled privately.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,438 +1,57 @@
-# AGENTS - Repository Maintenance Policy
+# AGENTS — Repository Policy (FCIS RFC 0001)
 
 ## Purpose and Scope
-
-This document defines the long-term maintenance policy for the **Fountain-Coach/midi2** repository, which contains:
-- Swift-based MIDI 2.0 reference implementation (UMP model, MIDI-CI, bridging libraries)
-- TypeScript/JavaScript library `midi2.js` for cross-browser MIDI 2.0 protocol support
-- Apple platform bridging packages (CoreMIDI, Audio Units)
-- Example applications and compliance tools
-
-The maintenance policy ensures:
-- Consistent quality and security standards across releases
-- Clear ownership and accountability for repository components
-- Sustainable long-term development and support
-- Rapid response to security incidents and breaking changes
-
-## Roles and Responsibilities
-
-### Maintainers
-**Primary responsibilities:**
-- Review and merge pull requests
-- Triage and prioritize issues
-- Enforce code quality standards and DoD compliance
-- Manage releases and version bumps
-- Monitor CI/CD pipeline health
-
-**Required access:**
-- Write access to the repository
-- Access to GitHub Actions secrets for package publishing
-- Listed in `CODEOWNERS` file
-
-**Current maintainers:** See `.github/CODEOWNERS`
-
-### Release Manager
-**Primary responsibilities:**
-- Execute release checklist (see `RELEASE.md`)
-- Coordinate version bumps across Swift and JavaScript packages
-- Publish packages to registries (npm, Swift Package Manager)
-- Draft and publish GitHub Releases with changelog
-- Verify CI passes and coverage gates before tagging
-
-**Rotation:** Assigned per release cycle (typically every 2-4 weeks)
-
-**Sign up:** Comment on the current release milestone or contact maintainers via GitHub Discussions
-
-### Triage Lead
-**Primary responsibilities:**
-- Label incoming issues within 48 hours
-- Assign priority labels: `priority/critical`, `priority/high`, `priority/normal`, `priority/low`
-- Assign component labels: `area/swift`, `area/javascript`, `area/ci`, `area/docs`
-- Route security issues to Security Contact
-- Close stale or duplicate issues
-
-**Rotation:** Weekly rotation among maintainers
-
-**Sign up:** See maintainer rotation schedule in GitHub wiki or Discussions
-
-### Security Contact
-**Primary responsibilities:**
-- Monitor security advisories and dependabot alerts
-- Coordinate vulnerability disclosure and patching
-- Trigger emergency releases for critical CVEs
-- Maintain `SECURITY.md` and coordinate with GitHub Security Lab
-
-**Contact:** See `SECURITY.md` for current security contact
-
-### CI Owner
-**Primary responsibilities:**
-- Monitor CI pipeline health and resolve build failures
-- Update GitHub Actions workflows and dependencies
-- Maintain build matrix (Swift, Node.js versions)
-- Enforce coverage gates and quality checks
-- Review and approve dependabot PRs for GitHub Actions
-
-**SLA:** Fix failing CI within 24 hours for `main` branch; 72 hours for feature branches
-
-**Current CI Owner:** See `.github/CODEOWNERS` for `/.github/workflows/` ownership
-
-## On-Call and Rotation Policy
-
-### Rotation Schedule
-- **Triage Lead:** Weekly rotation (Monday to Sunday)
-- **Release Manager:** Per-release rotation (assigned when milestone created)
-- **CI Owner:** Monthly rotation
-- **Security Contact:** Fixed assignment, backup rotates quarterly
-
-### Sign-up Process
-1. Join the maintainers team (requires write access)
-2. Add your availability to the rotation schedule in GitHub wiki
-3. Comment on the pinned rotation issue to claim a slot
-4. Receive handoff notes from previous rotation holder
-
-### Typical Cadence
-- **Daily:** Triage new issues/PRs (Triage Lead)
-- **Weekly:** Review dependabot PRs, run `MAINTENANCE.md` weekly tasks
-- **Monthly:** Release planning, dependency audits, CI health review
-- **Quarterly:** Security audit, documentation refresh, archival review
-
-## Triage Workflow
-
-### Issue Triage (within 48 hours of creation)
-1. **Validate:** Ensure issue has sufficient detail, reproducible steps, or use case
-2. **Label:**
-   - **Type:** `bug`, `enhancement`, `documentation`, `question`, `security`
-   - **Area:** `area/swift`, `area/javascript`, `area/ci`, `area/docs`, `area/examples`
-   - **Priority:** `priority/critical`, `priority/high`, `priority/normal`, `priority/low`
-3. **Assign:** 
-   - Critical/High priority: Assign to maintainer or next milestone
-   - Normal/Low: Leave unassigned or add to backlog milestone
-4. **Security issues:** Immediately label `security`, remove public visibility if needed, contact Security Contact
-5. **Duplicate/Invalid:** Close with reference to original issue or explanation
-
-### Pull Request Triage (within 24 hours of creation)
-1. **Validate:**
-   - CI must be green (Swift tests, TypeScript tests, coverage gate ≥80%)
-   - PR description includes context and links to related issue
-   - Changes include tests if modifying behavior
-2. **Review:**
-   - Assign at least one maintainer for code review
-   - Request changes if DoD not met (see `CONTRIBUTING.md`)
-   - Security-sensitive changes require Security Contact approval
-3. **Merge:**
-   - Squash-merge for feature PRs
-   - Require status checks: `build-test`, `test (midi2.js)`, coverage gate
-   - Update `CHANGELOG.md` "Unreleased" section before merging
-
-### Staleness Policy
-- **Issues:** Auto-close after 90 days of inactivity with `stale` label and 14-day warning
-- **PRs:** Auto-close after 30 days of inactivity with `stale` label and 7-day warning
-- **Override:** Apply `keep-open` label to exempt from staleness automation
-
-## Release Process Overview
-
-See **`RELEASE.md`** for detailed step-by-step checklist.
-
-**Summary:**
-1. Ensure CI is green and coverage ≥80%
-2. Update `CHANGELOG.md` from "Unreleased" to version section
-3. Bump version in `Package.swift` and `midi2.js/package.json`
-4. Create signed git tag: `git tag -s v0.X.Y -m "Release v0.X.Y"`
-5. Push tag: `git push origin v0.X.Y`
-6. Build and publish npm package: `cd midi2.js && npm run build && npm publish`
-7. Draft GitHub Release with changelog excerpt
-8. Announce release in GitHub Discussions and relevant channels
-
-**Versioning:** Follow [Semantic Versioning 2.0.0](https://semver.org/)
-- MAJOR: Breaking API changes
-- MINOR: New features, backward-compatible
-- PATCH: Bug fixes, backward-compatible
-
-## Dependency Maintenance
-
-### Dependabot Configuration
-- **Location:** `.github/dependabot.yml`
-- **Ecosystems:** `github-actions`, `npm` (midi2.js), `swift` (Package.swift)
-- **Frequency:** Weekly checks (Mondays at 09:00 UTC)
-- **Auto-merge policy:**
-  - Patch updates: Auto-approve if CI passes
-  - Minor updates: Require maintainer review
-  - Major updates: Require maintainer review and migration testing
-
-### Security Overrides
-- **Critical CVEs:** Merge immediately after CI passes, trigger patch release within 24 hours
-- **High-severity:** Merge within 72 hours, include in next scheduled release
-- **Moderate/Low:** Review in next weekly triage, include in next release
-
-### Manual Dependency Updates
-- Run `npm audit` weekly in `midi2.js/` and address high/critical vulnerabilities
-- Review Swift package updates quarterly
-- Check for outdated GitHub Actions monthly: `gh api repos/:owner/:repo/actions/workflows --jq '.workflows[].path' | xargs -I {} grep 'uses:' {}`
-
-## CI and Testing Ownership
-
-### CI Pipeline Components
-1. **Swift CI** (`.github/workflows/ci.yml`): Build, test, coverage (≥80%)
-2. **TypeScript CI** (`.github/workflows/midi2-js.yml`): Type check, test, build, coverage
-3. **Compliance Tests** (`.github/workflows/midi2-compliance.yml`, `compliance-swift.yml`): MIDI Association Workbench validation
-
-### CI Owner Responsibilities
-- Monitor failing builds on `main` branch
-- Fix CI failures within 24 hours (main), 72 hours (PRs)
-- Update build matrix when new Swift/Node.js versions release
-- Review and approve dependabot PRs for GitHub Actions
-- Maintain build cache efficiency
-
-### Required Status Checks
-Enable branch protection on `main` with required status checks:
-```
-Settings → Branches → main → Require status checks to pass before merging:
-  ✓ build-test
-  ✓ test (midi2.js)
-  ✓ Enforce coverage gate (>=80%)
-```
-
-### Test Infrastructure Ownership
-- **Swift tests:** Located in `Tests/`, use `swift test` to run
-- **TypeScript tests:** Located in `midi2.js/src/`, use `npm test` in `midi2.js/` directory
-- **Coverage reporting:** Enforced at ≥80% for both ecosystems
-
-## Security Incident Response
-
-### Contact
-See **`SECURITY.md`** for current security contact email and PGP key.
-
-### Severity Levels
-- **Critical (CVSS 9.0-10.0):** Immediate response, patch within 24 hours, emergency release
-- **High (CVSS 7.0-8.9):** Patch within 72 hours, include in next scheduled release or hotfix
-- **Medium (CVSS 4.0-6.9):** Patch within 2 weeks, include in next minor release
-- **Low (CVSS 0.1-3.9):** Patch within 1 month, include in next release
-
-### CVE and Patching Workflow
-1. **Report received:** Acknowledge within 24 hours via security contact
-2. **Validation:** Reproduce vulnerability and assess severity
-3. **Private fix:** Develop patch in private fork or security advisory draft
-4. **Disclosure coordination:** Coordinate with reporter on disclosure timeline (typically 90 days)
-5. **Release:** Publish patched version, GitHub Security Advisory, and CVE if applicable
-6. **Announcement:** Post security advisory to GitHub Discussions and update `SECURITY.md`
-
-### GitHub Security Features to Enable
-```
-Settings → Security & analysis:
-  ✓ Dependency graph
-  ✓ Dependabot alerts
-  ✓ Dependabot security updates
-  ✓ Code scanning (CodeQL)
-  ✓ Secret scanning
-```
-
-## Deprecation and Breaking Change Policy
-
-### Deprecation Process
-1. **Announce:** Add deprecation notice in code comments and documentation
-2. **Timeline:** Maintain deprecated APIs for at least one MINOR version (e.g., if deprecated in v0.7.0, remove in v0.9.0)
-3. **Warnings:** Emit warnings or compile-time notices where feasible
-4. **Migration guide:** Provide migration examples in `CHANGELOG.md` and documentation
-5. **Removal:** Remove in next MAJOR version with clear CHANGELOG entry
-
-### Breaking Changes
-- **Permitted in:** MAJOR version bumps only (v1.0.0 → v2.0.0)
-- **Documentation:** List all breaking changes in `CHANGELOG.md` under "Breaking" section
-- **Migration guide:** Provide step-by-step migration instructions in release notes
-- **Pre-release testing:** Tag release candidates (e.g., v2.0.0-rc.1) and request community feedback
-
-## Archival and Sunsetting Policy
-
-### Archival Criteria
-A repository or package may be archived if:
-- No commits for 12 consecutive months
-- Maintainers unanimously vote to sunset
-- Critical security vulnerability cannot be patched
-- Technology stack becomes unsupported (e.g., Swift 6 EOL)
-
-### Sunsetting Process
-1. **Announcement:** Post intent to archive in GitHub Discussions and README (90-day notice)
-2. **Final release:** Tag final version with clear "end-of-life" notice in release notes
-3. **Documentation update:** Add deprecation banner to README and docs
-4. **Archive:** Mark repository as archived in GitHub settings
-5. **Registry:** Deprecate npm package if applicable: `npm deprecate @fountain-coach/midi2 "No longer maintained"`
-
-## Onboarding Guide for New Maintainers
-
-### Minimum Required Access
-- **GitHub:** Write access to `Fountain-Coach/midi2` repository
-- **npm:** Publish access to `@fountain-coach/midi2` package (request from existing maintainer)
-- **Communication:** Access to maintainer Slack/Matrix/Discord (if applicable)
-
-### Onboarding Steps
-1. **Read documentation:** Review `README.md`, `CONTRIBUTING.md`, `RELEASE.md`, this file
-2. **Local setup:**
-   ```bash
-   git clone https://github.com/Fountain-Coach/midi2.git
-   cd midi2
-   
-   # Swift setup
-   swift build
-   swift test
-   
-   # JavaScript setup
-   cd midi2.js
-   npm install
-   npm run check
-   npm test
-   ```
-3. **Access requests:**
-   - Request write access from existing maintainer
-   - Request npm publish access: `npm owner add <username> @fountain-coach/midi2`
-   - Request addition to `.github/CODEOWNERS`
-4. **Shadow rotation:** Pair with existing Triage Lead or Release Manager for one cycle
-5. **First tasks:**
-   - Triage 5 issues
-   - Review 3 pull requests
-   - Perform weekly maintenance checklist (see `MAINTENANCE.md`)
-
-## Escalation Matrix and Communication Channels
-
-### GitHub-based Communication (primary)
-- **Issues:** Bug reports, feature requests, questions
-- **Pull Requests:** Code reviews, implementation discussions
-- **Discussions:** General Q&A, announcements, RFCs
-- **Security Advisories:** Private vulnerability reports (see `SECURITY.md`)
-
-### External Channels (if configured)
-- **Slack/Matrix:** Real-time maintainer coordination (URL: TBD - update when configured)
-- **Email:** Security contact (see `SECURITY.md`), maintainer mailing list (TBD)
-
-### Escalation Path
-1. **Issue author → Triage Lead** (via issue comments)
-2. **Triage Lead → Maintainers** (via @-mention in issue or Discussions)
-3. **Maintainers → Security Contact** (for security issues)
-4. **Security Contact → GitHub Security Lab** (for critical vulnerabilities affecting broader ecosystem)
-
-### Response Time Expectations
-- **Triage:** 48 hours for issue labeling
-- **PR review:** 72 hours for initial review
-- **Security report:** 24 hours for acknowledgment
-- **Critical CI failure:** 24 hours for fix on `main` branch
-
-## Monthly and Quarterly Maintenance Tasks
-
-### Weekly Tasks (run every Monday, see `MAINTENANCE.md` for commands)
-- Review new issues and PRs (Triage Lead)
-- Review and merge dependabot PRs
-- Check CI health and flaky tests
-- Update `CHANGELOG.md` if features merged
-
-### Monthly Tasks
-- **Dependency audit:** Run `npm audit` in `midi2.js/`, check Swift package updates
-- **CI review:** Review GitHub Actions usage, update runner versions if needed
-- **Documentation sync:** Ensure README, CONTRIBUTING, and API docs reflect current state
-- **Release planning:** Create next milestone, review backlog
-
-### Quarterly Tasks (run first week of Q1, Q2, Q3, Q4)
-- **Security audit:** Review dependabot alerts, run `npm audit --production`, check for Swift CVEs
-- **Performance review:** Profile critical paths (UMP encoding/decoding, scheduler)
-- **Documentation refresh:** Update examples, fix broken links, refresh badges
-- **Archival review:** Close stale issues/PRs, archive outdated branches
-- **Compliance review:** Verify spec adherence with latest MIDI 2.0 specifications
-
----
-
-## Templates
-
-### Issue Template: Bug Report
-**File:** `.github/ISSUE_TEMPLATE/bug_report.md`
-```markdown
----
-name: Bug Report
-about: Report a bug or unexpected behavior
-labels: bug
----
-
-## Description
-<!-- Clear description of the bug -->
-
-## Steps to Reproduce
-1. 
-2. 
-3. 
-
-## Expected Behavior
-<!-- What should happen -->
-
-## Actual Behavior
-<!-- What actually happens -->
-
-## Environment
-- OS: [e.g., macOS 13.5, Ubuntu 22.04, Windows 11]
-- Swift version (if applicable): [e.g., 6.2.1]
-- Node.js version (if applicable): [e.g., 20.10.0]
-- Package version: [e.g., midi2 0.7.0]
-
-## Additional Context
-<!-- Logs, screenshots, related issues -->
-```
-
-### Issue Template: Feature Request
-**File:** `.github/ISSUE_TEMPLATE/feature_request.md`
-```markdown
----
-name: Feature Request
-about: Suggest a new feature or enhancement
-labels: enhancement
----
-
-## Problem Statement
-<!-- What problem does this feature solve? -->
-
-## Proposed Solution
-<!-- How should this feature work? -->
-
-## Alternatives Considered
-<!-- Other approaches you've considered -->
-
-## Additional Context
-<!-- Use cases, examples, references -->
-```
-
-### Issue Template: Security Vulnerability
-**File:** `.github/ISSUE_TEMPLATE/security_report.md`
-```markdown
----
-name: Security Vulnerability
-about: Report a security vulnerability (use private reporting if possible)
-labels: security
----
-
-## ⚠️ Security Notice
-**Please do not report security vulnerabilities publicly.**
-
-Use GitHub's private security advisory feature or email the security contact listed in [SECURITY.md](../SECURITY.md).
-
-This template is for tracking public security discussions only.
-```
-
-### Maintenance Checklist Template
-**Copy into maintenance tracking issue or project board:**
-```markdown
-## Weekly Maintenance Checklist
-- [ ] Review new issues (triage lead)
-- [ ] Review new PRs (maintainers)
-- [ ] Merge dependabot PRs if CI passes
-- [ ] Check CI health dashboard
-- [ ] Update CHANGELOG.md if features merged
-
-## Monthly Maintenance Checklist
-- [ ] Run `npm audit` in midi2.js/
-- [ ] Check Swift package dependency updates
-- [ ] Review GitHub Actions versions
-- [ ] Create next release milestone
-- [ ] Review backlog and close stale issues
-
-## Quarterly Maintenance Checklist
-- [ ] Security audit (dependabot + manual review)
-- [ ] Performance profiling
-- [ ] Documentation refresh (README, badges, examples)
-- [ ] Archival review (close stale items)
-- [ ] Compliance review (MIDI 2.0 spec updates)
-```
+This document defines the behavioral invariants and routing rules for **Fountain-Coach/midi2**. It is policy-only and contains no procedures or tool configuration.
+
+## Behavioral Invariants
+- All changes land via pull request; the default branch is protected by required status checks.
+- Coverage targets remain at or above 80% for Swift and JavaScript test suites.
+- Releases follow Semantic Versioning and include a changelog update and a signed tag.
+- Security reports are handled per `SECURITY.md` with coordinated disclosure.
+- Dependency updates follow the documented Dependabot policy and severity SLAs.
+- Breaking changes are allowed only in major releases; deprecations persist for at least one minor release with migration guidance.
+- Staleness policy applies: issues close after 90 days of inactivity, PRs after 30 days, unless `keep-open` is applied.
+- This repo does not require MCP configuration for correctness.
+
+## Roles and Ownership
+- **Maintainers:** Review/merge PRs, enforce quality standards, manage releases, monitor CI.
+- **Release Manager:** Coordinate version bumps and package publishing per release cycle.
+- **Triage Lead:** Label and prioritize issues within SLA; route security issues.
+- **Security Contact:** Own vulnerability intake and disclosure coordination.
+- **CI Owner:** Maintain CI health, workflows, and coverage gates.
+
+## Cadence and SLAs
+- Issue labeling within 48 hours.
+- PR initial review within 72 hours.
+- Critical CI failures fixed within 24 hours on `main`.
+
+## Routing (Where to Go for What)
+
+### Planning Protocol
+- Use `PLANS.md` for any multi-step or high-risk work. Plans capture intent and acceptance criteria, not procedures.
+
+### Execution Runbooks (Skills)
+- Triage workflow: `.codex/skills/triage-workflow/SKILL.md`
+- Release process: `.codex/skills/release-process/SKILL.md`
+- Dependency maintenance: `.codex/skills/dependency-maintenance/SKILL.md`
+- CI operations: `.codex/skills/ci-operations/SKILL.md`
+- Security incident response: `.codex/skills/security-incident-response/SKILL.md`
+- Onboarding maintainers: `.codex/skills/onboarding-maintainers/SKILL.md`
+- Maintenance cadence: `.codex/skills/maintenance-cadence/SKILL.md`
+- Deprecation lifecycle: `.codex/skills/deprecation-lifecycle/SKILL.md`
+- Sunsetting/archival: `.codex/skills/sunsetting/SKILL.md`
+- Spec PDF to schema mapping: `.codex/skills/spec-pdf-to-schema/SKILL.md`
+- midi2.js workflow: `.codex/skills/midi2-js-workflow/SKILL.md`
+
+### Operational References
+- Release checklist: `RELEASE.md`
+- Maintenance commands: `MAINTENANCE.md`
+- Contribution workflow: `CONTRIBUTING.md`
+- Security policy: `SECURITY.md`
+- Issue/PR templates: `.github/ISSUE_TEMPLATE/`, `.github/PULL_REQUEST_TEMPLATE.md`
+
+### Roadmap
+- Product/status roadmap: `PLAN.md` (non-FCIS planning)
+
+### Legacy Notes
+- `legacy/AGENTS.md` and `legacy/midi2-js-AGENTS.md` are archival references; current policy is defined here.

--- a/FCIS_AUDIT.md
+++ b/FCIS_AUDIT.md
@@ -1,0 +1,37 @@
+# FCIS Audit (RFC 0001)
+
+## Executive Summary
+Status: **COMPLIANT**
+
+Top findings resolved:
+- `AGENTS.md` is now policy-only and routes execution details to Skills.
+- `PLANS.md` exists and is required for multi-step/high-risk work.
+- `.codex/skills/*/SKILL.md` modules capture runbooks previously embedded in AGENTS/PLAN docs.
+
+## Repository Inventory
+- Behavioral policy: `AGENTS.md`
+- Planning protocol: `PLANS.md`
+- Roadmap/status: `PLAN.md`
+- Skills: `.codex/skills/*/SKILL.md`
+- Operational runbooks (referenced by skills): `RELEASE.md`, `MAINTENANCE.md`, `CONTRIBUTING.md`, `SECURITY.md`
+- Legacy policy stubs: `legacy/AGENTS.md`, `legacy/midi2-js-AGENTS.md`
+- Issue/PR templates: `.github/ISSUE_TEMPLATE/*`, `.github/PULL_REQUEST_TEMPLATE.md`
+- MCP config: none
+
+## Compliance Matrix
+| Requirement ID | Requirement (short) | Status | Evidence | Fix recommendation |
+| --- | --- | --- | --- | --- |
+| FCIS-AGENTS-1 | AGENTS defines invariants and routing only | PASS | `AGENTS.md` lists invariants and routes to `PLANS.md` and Skills; no procedures included. | None. |
+| FCIS-AGENTS-2 | AGENTS contains no step-by-step procedures or tool configs | PASS | `AGENTS.md` is declarative and points to `.codex/skills/*/SKILL.md`. | None. |
+| FCIS-PLANS-1 | PLANS protocol exists and is required for multi-step/high-risk work | PASS | `PLANS.md` defines protocol; `AGENTS.md` requires it. | None. |
+| FCIS-PLANS-2 | Plan content is intent/why, not runbooks | PASS | `PLANS.md` template is intent-focused; `PLAN.md` is roadmap-only. | None. |
+| FCIS-SKILLS-1 | Skills exist with purpose/when/steps/output | PASS | `.codex/skills/*/SKILL.md` modules include purpose, when-to-use, steps, output contract. | None. |
+| FCIS-LAYER-1 | Orthogonality across layers | PASS | AGENTS = policy, PLANS = intent, Skills = execution. | None. |
+| FCIS-MCP-1 | MCP is capability-only and not required | PASS | No MCP configuration or dependency in repo. | None. |
+
+## Orthogonality Violations
+- None observed after remediation. Execution guidance is routed through Skills.
+
+## Risks / Drift Vectors
+- Operational runbooks (`RELEASE.md`, `MAINTENANCE.md`) may drift from Skills; keep Skills updated when runbooks change.
+- Legacy stubs could be expanded unintentionally; keep them archival-only.

--- a/FCIS_COMPLIANCE_PLAN.md
+++ b/FCIS_COMPLIANCE_PLAN.md
@@ -1,0 +1,76 @@
+# FCIS Compliance Plan (RFC 0001)
+
+## Goal & Scope
+Bring `Fountain-Coach/midi2` into FCIS RFC 0001 compliance by separating policy (AGENTS), planning protocol (PLANS), and execution techniques (Skills) with minimal, non-destructive edits.
+
+## Minimal-Change Strategy
+- Keep existing docs (e.g., `RELEASE.md`, `MAINTENANCE.md`, `CONTRIBUTING.md`) intact.
+- Extract runbooks from `AGENTS.md`/`PLAN.md` into focused Skills.
+- Convert `AGENTS.md` into declarative invariants and routing only.
+- Add `PLANS.md` as the required planning protocol; keep `PLAN.md` as roadmap/status.
+
+## Phased Plan with Acceptance Criteria
+
+### Phase 0: Safety (no behavior change)
+**Steps**
+- Verify repository is allowlisted and working tree is clean.
+- Create a feature branch for compliance work.
+
+**Files**: none
+
+**Acceptance criteria**
+- Branch `fcs/rfc0001-compliance` exists; no direct `main` edits.
+
+### Phase 1: Establish required files/structure
+**Steps**
+1. Create `PLANS.md` with FCIS plan protocol (purpose, when-to-use, required sections, status tracking).
+2. Create `.codex/skills/*/SKILL.md` modules for runbooks currently embedded in `AGENTS.md` and `PLAN.md`.
+
+**Files**
+- Create `PLANS.md`
+- Create `.codex/skills/triage-workflow/SKILL.md`
+- Create `.codex/skills/release-process/SKILL.md`
+- Create `.codex/skills/dependency-maintenance/SKILL.md`
+- Create `.codex/skills/ci-operations/SKILL.md`
+- Create `.codex/skills/security-incident-response/SKILL.md`
+- Create `.codex/skills/onboarding-maintainers/SKILL.md`
+- Create `.codex/skills/maintenance-cadence/SKILL.md`
+- Create `.codex/skills/deprecation-lifecycle/SKILL.md`
+- Create `.codex/skills/sunsetting/SKILL.md`
+- Create `.codex/skills/spec-pdf-to-schema/SKILL.md`
+- Create `.codex/skills/midi2-js-workflow/SKILL.md`
+
+**Acceptance criteria**
+- `PLANS.md` exists and is referenced from `AGENTS.md`.
+- Each skill has purpose, when-to-use, steps, and output contract.
+
+### Phase 2: Refactor content for orthogonality
+**Steps**
+1. Rewrite `AGENTS.md` as declarative policy and routing (no procedures or templates).
+2. Remove step-by-step procedures from `AGENTS.md`, referencing Skills instead.
+3. Update `PLAN.md` to clarify it is a roadmap/status doc and remove execution commands.
+4. Trim legacy AGENTS files to archival stubs that point to Skills (procedures preserved in skills).
+
+**Files**
+- Edit `AGENTS.md` (remove procedures, add routing to `PLANS.md` + skills)
+- Edit `PLAN.md` (roadmap only, no commands)
+- Edit `legacy/AGENTS.md`, `legacy/midi2-js-AGENTS.md` (archival stubs + pointers)
+
+**Acceptance criteria**
+- `AGENTS.md` contains no step lists, commands, or templates.
+- `PLAN.md` contains only intent/status content.
+- Legacy AGENTS files no longer contain procedures.
+
+### Phase 3: Validation & enforcement notes
+**Steps**
+1. Ensure AGENTS explicitly states: use `PLANS.md` for multi-step/high-risk work; Skills are the sole execution runbooks.
+2. Ensure no MCP dependency is introduced.
+3. Record compliance status update in `FCIS_AUDIT.md` if needed.
+
+**Files**
+- Confirm `AGENTS.md` references `PLANS.md` and `.codex/skills/*`.
+- (Optional) Update `FCIS_AUDIT.md` note about remediation.
+
+**Acceptance criteria**
+- FCIS layers are orthogonal and discoverable.
+- Repo does not require MCP to operate.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,8 @@
 
 **Version**: 0.9.0 | **Last Updated**: 2025-12-16
 
+This file is a roadmap/status snapshot. Planning protocol is in `PLANS.md`, and procedures live in `.codex/skills/*/SKILL.md`.
+
 ## Completed (v0.9.0)
 - ✅ Schema/OpenAPI alignment: Data (MDS), Stream, Flex, and SysEx coverage complete in midi2.js with schema-bridge round-trips and negative tests
 - ✅ Swift stream and data helpers at schema parity: endpoint info, device identity, name, product instance, function block name/flags, filter bitmap
@@ -24,7 +26,7 @@
 - DoD validation automation (Gap 10.2.1)
 - UMP format extensions documentation (Gap 1.2.2)
 
-## Maintenance
-- Keep docs in sync: regenerate OpenAPI-derived types when schema changes; validate via `npm run check && npm test` and Swift unit/integration suites
-- Follow release process in RELEASE.md for version bumps
-- Track gaps in docs/gap-closure-tracker.md
+## Maintenance Notes
+- Keep docs in sync when schema changes (see relevant Skills).
+- Follow release process in `RELEASE.md` for version bumps.
+- Track gaps in `docs/gap-closure-tracker.md`.

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,41 @@
+# PLANS Protocol (FCIS RFC 0001)
+
+## Purpose
+Define the planning protocol for multi-step or high-risk work in this repository. Plans capture intent, scope, and acceptance criteria before implementation begins.
+
+## When a Plan Is Required
+A plan is required when work is:
+- Multi-step or cross-cutting across packages
+- Release-related or security-sensitive
+- Likely to change public APIs, CI, or compliance artifacts
+- Non-trivial refactors or migrations
+
+## Plan Format (Template)
+A plan must answer **what** and **why**, not **how**. Use this template in issues, PRs, or planning docs:
+
+```
+Goal:
+Scope:
+Non-goals:
+Constraints:
+Dependencies:
+Risks:
+Steps:
+  - [ ] Step 1 (intent + outcome)
+  - [ ] Step 2 (intent + outcome)
+Validation:
+Acceptance Criteria:
+```
+
+## Status Conventions
+- `pending` / `in_progress` / `completed`
+- One `in_progress` step at a time
+
+## Storage
+Plans may live in:
+- The PR description
+- An issue description
+- A dedicated planning document referenced by the PR
+
+## Relationship to Skills
+Execution details belong in `.codex/skills/*/SKILL.md`. Plans should link to relevant skills rather than include procedures.

--- a/legacy/AGENTS.md
+++ b/legacy/AGENTS.md
@@ -1,34 +1,14 @@
-# AGENTS
+# AGENTS (Archived)
 
-> **📦 ARCHIVED**: This document is retained for historical reference. The current maintenance policy is in:
-> - [`AGENTS.md`](../AGENTS.md) - Comprehensive repository maintenance policy
-> - [`MAINTENANCE.md`](../MAINTENANCE.md) - Practical maintenance procedures
-> - [`CONTRIBUTING.md`](../CONTRIBUTING.md) - Development workflow and guidelines
->
-> **Superseded**: December 2025
+This document is retained for historical reference only and is not authoritative.
 
-## Scope and standards
-- Repository spans the Swift MIDI 2.0 reference stack and the CoreMIDI-free `midi2.js` TypeScript port. Treat `midi2.js` as the browser/runtime-facing library; keep it decoupled from platform APIs.
-- Definition of Done for `midi2.js` lives in `docs/midi2-js-dod.md`; design intent is outlined in `docs/midi2-stack-essay.md` and the normative schema/OpenAPI at the repo root.
-- Local gates to run before pushing `midi2.js` changes: `npm run check` and `npm test` (working directory `midi2.js`). CI workflow `.github/workflows/midi2-js.yml` mirrors this.
-- Keep documentation in sync: update this file, `midi2.js/AGENTS.md`, and the gap plan when protocol coverage or public APIs shift. When code moves ahead of the spec PDFs, reconcile `midi2.full.closed.schema.json` / `midi2.full.openapi.json` or document the delta and source page.
-- When using PDF specs to inform implementation, extract the relevant pages to images and map them back to the canonical JSON artifacts (`midi2.full.closed.schema.json`, `midi2.full.openapi.json`). Any protocol facts derived from PDFs must be reflected in those JSON sources or documented as a pending delta; do not land code based on PDFs alone without updating/annotating the canonical sources.
+Current policy and routing:
+- Policy: `AGENTS.md`
+- Planning protocol: `PLANS.md`
+- Execution runbooks: `.codex/skills/*/SKILL.md`
 
-## Active workstreams
-- `midi2.js`: see `midi2.js/AGENTS.md` for day-to-day expectations, current gaps, and DoD alignment.
-- `midi2demo` CLI (Swift): goal is a teaching CLI that round-trips UMP, SysEx7/8, Flex Data, and MIDI-CI flows. Expected commands: `note-on`, `sysex7/8`, `flex`, `ci-handshake`, and `inspect`, with ArgumentParser wiring, integration tests, and README/man-page coverage.
+Archived content from this file has been preserved in Skills:
+- Spec PDF mapping: `.codex/skills/spec-pdf-to-schema/SKILL.md`
+- midi2.js workflow: `.codex/skills/midi2-js-workflow/SKILL.md`
 
-## Maintenance rules
-- Prefer ESM + type-safe exports; avoid platform-specific globals in the core library.
-- Keep release notes and conformance artifacts current when closing DoD items; avoid introducing new vendored artifacts (e.g., `node_modules` or built `dist/`) without a clear reason.
-- When adding protocol surface area, mirror coverage in tests and update `docs/midi2-js-dod.md` and `midi2.js/docs/gap-plan.md`.
-- PDF-to-JSON mapping procedure:
-  1) Render the specific spec page(s) to PNG (e.g., `gs -sDEVICE=png16m -o /tmp/page.png -dFirstPage=N -dLastPage=N M2-104-UM_v1-1-2_UMP_and_MIDI_2-0_Protocol_Specification.pdf`).
-  2) Manually read/verify the bit layout or field definitions from the image.
-  3) Update `midi2.full.closed.schema.json` and `midi2.full.openapi.json` to reflect the extracted facts, with comments in AGENTS noting the source page/section.
-  4) Only then implement code/tests against the updated canonical JSON; document any gaps if the schema cannot be updated immediately.
-
-## Recent midi2.js history (for audit)
-- 40caf31 — Flex Data coverage expanded (key signature, lyric/text handling).
-- 56541bd — Utility MT=0 and MIDI 1.0 channel voice encode/decode; Flex tempo/time signature added.
-- 0b07551 — Initial `midi2.js` drop: UMP helpers, SysEx7/8, MIDI-CI envelopes, scheduler, adapters, and DoD doc.
+Superseded: 2025-12

--- a/legacy/midi2-js-AGENTS.md
+++ b/legacy/midi2-js-AGENTS.md
@@ -1,29 +1,13 @@
-# midi2.js / AGENTS
+# midi2.js / AGENTS (Archived)
 
-> **📦 ARCHIVED**: This document is retained for historical reference. Current documentation is maintained in:
-> - [`AGENTS.md`](../AGENTS.md) - Comprehensive repository maintenance policy
-> - [`docs/gap-closure-tracker.md`](../docs/gap-closure-tracker.md) - Active gap tracking
-> - [`midi2.js/README.md`](../midi2.js/README.md) - Library documentation
->
-> **Last Active Version**: 0.7.0 | **Current Version**: 0.9.0
+This document is retained for historical reference only and is not authoritative.
 
-## Mission and current coverage
-- Cross-browser TypeScript core for MIDI 2.0 UMP + MIDI-CI with no CoreMIDI/DOM dependencies in the core exports.
-- Implemented (0.7.0): UMP encode/decode for utility/system/channel voice 1.0 & 2.0 (incl. per-note management/registered/assignable controllers and per-note pitch bend); Flex Data; SysEx7/8 fragmentation + reassembly; MIDI-CI envelopes (discovery, profiles, property exchange with chunking, process inquiry); scheduler with JR-aware clocks + record/replay; streaming decoder that reassembles SysEx and surfaces MIDI-CI; adapters for WebAudio/Three.js/Cannon.js; OpenAPI-derived runtime guards from `midi2.full.openapi.json`.
-- Tests: `npm run ci` (codegen + tsc + vitest) covers UMP, SysEx, MIDI-CI helpers, scheduler, and the stream decoder. CI mirrors this in `.github/workflows/midi2-js.yml`.
-- Build: `npm run build` (tsup) emits ESM+CJS+types to `dist/`; package is public `@fountain-coach/midi2@0.7.0`.
-- Canonical sources: protocol facts must originate from `midi2.full.closed.schema.json` / `midi2.full.openapi.json`. When extracting details from PDF specs, render the relevant pages (e.g., `gs -sDEVICE=png16m -o /tmp/page.png -dFirstPage=N -dLastPage=N M2-104-UM_v1-1-2_UMP_and_MIDI_2-0_Protocol_Specification.pdf`), interpret the bit layout, and update/annotate the JSON schema/OpenAPI accordingly before changing code. Document the source section/page for any derived behaviors.
+Current policy and routing:
+- Policy: `AGENTS.md`
+- Planning protocol: `PLANS.md`
+- Execution runbooks: `.codex/skills/*/SKILL.md`
 
-## Gaps vs DoD (sync with `docs/midi2-js-dod.md` and `midi2.js/docs/gap-plan.md`)
-- Protocol: Endpoint/Device Info payload fidelity and GTB semantics still need tightening; reserved/unsupported statuses need explicit handling across decoders. Worker-clock JR projection needs broader coverage.
-- MIDI-CI: compression/error/NAK paths and MUID management need negative tests; profile detail/added-removed reports still light; compression paths untested.
-- Validation: broaden reserved-bit/range enforcement and malformed stream/flex/CI envelope tests; add oversize SysEx and invalid chunk-order tests.
-- Adapters: expand coverage for per-note controllers/pitch-bend range negotiation and disposal safety.
-- Tooling/distribution: keep coverage reporting and publish gating in CI; ensure `dist/` is reproducible from a clean lock.
-- Docs: keep README, DoD, and gap plan aligned when surface area changes; note schema deltas explicitly.
+Archived workflow content is preserved in:
+- `.codex/skills/midi2-js-workflow/SKILL.md`
 
-## Workflow
-- Default commands (run from `midi2.js`): `npm run check`, `npm test`, `npm run build`. Vitest here does not support `--runInBand`.
-- Add tests alongside new protocol handlers; prefer `Uint32Array`/`Uint8Array` fixtures that mirror JSON Schema/OpenAPI expectations.
-- Update `AGENTS.md`, `docs/midi2-js-dod.md`, and `midi2.js/docs/gap-plan.md` when adding/removing protocol surface area or changing public APIs.
-- Keep core logic in `src/*` platform-agnostic; adapters stay isolated under `src/adapters/*`.
+Superseded: 2025-12

--- a/midi2.js/.ci-trigger
+++ b/midi2.js/.ci-trigger
@@ -1,2 +1,2 @@
 # Touch file to trigger midi2.js CI for docs-only PRs.
-# Refresh for 0.9.0 documentation update.
+# Refresh for FCIS RFC 0001 compliance.


### PR DESCRIPTION
## Summary
- Make AGENTS policy-only and add routing to PLANS and Skills
- Add PLANS protocol and Skills for triage/release/deps/CI/security/onboarding/etc.
- Trim legacy AGENTS docs to archival stubs and keep PLAN as roadmap
- Touch `midi2.js/.ci-trigger` to satisfy required JS CI check

## Moves
- AGENTS/PLAN/legacy runbooks -> `.codex/skills/*/SKILL.md`
- Templates referenced via `.github/ISSUE_TEMPLATE/*`

## N/A
- MCP configuration: repo does not use MCP, so no config required

## Testing
- Not run locally (documentation-only changes)
